### PR TITLE
[MM-18519] Add Mattermost CLI command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -15,7 +15,7 @@ create [name] [flags]
 	Creates a Mattermost installation.
 	Flags:
 %s
-example: /cloud create myinstallation --saml onelogin --test-data
+	example: /cloud create myinstallation --saml onelogin --test-data
 
 list
 	Lists the Mattermost installations created by you.
@@ -24,16 +24,22 @@ upgrade [name] [flags]
 	Upgades a Mattermost installaton.
 	Flags:
 %s
-example: /cloud upgrade myinstallation --version 5.13.2
+	example: /cloud upgrade myinstallation --version 5.13.2
+
+mmcli [name] [mattermost-subcommand]
+	Runs Mattermost CLI commands on an installation.
+
+	example: /cloud mmcli myinstallation version
+		(equivalent to running 'mattermost version' on myinstallation)
 
 delete [name]
 	Deletes a Mattermost installation.
 `
-	return fmt.Sprintf(
+	return codeBlock(fmt.Sprintf(
 		help,
 		getCreateFlagSet().FlagUsages(),
 		getUpgradeFlagSet().FlagUsages(),
-	)
+	))
 }
 
 func getCommand() *model.Command {
@@ -42,7 +48,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Mattermost Private Cloud",
 		Description:      "This command allows spinning up and down Mattermost installations using Mattermost Private Cloud.",
 		AutoComplete:     false,
-		AutoCompleteDesc: "Available commands: create, list, delete",
+		AutoCompleteDesc: "Available commands: create, list, upgrade, mmcli, delete",
 		AutoCompleteHint: "[command]",
 	}
 }
@@ -84,6 +90,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	switch command {
 	case "create":
 		handler = p.runCreateCommand
+	case "mmcli":
+		handler = p.runMattermostCLICommand
 	case "list":
 		handler = p.runListCommand
 	case "upgrade":

--- a/server/command_cli.go
+++ b/server/command_cli.go
@@ -1,23 +1,27 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+	"strings"
 
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
 )
 
-func (p *Plugin) runCLICommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+func (p *Plugin) runMattermostCLICommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
 	if len(args) == 0 {
 		return nil, true, errors.New("must provide an installation name")
 	}
 
 	name := args[0]
-
 	if name == "" {
 		return nil, true, errors.New("must provide an installation name")
+	}
+
+	subcommand := args[1:]
+	if len(subcommand) == 0 {
+		return nil, true, errors.New("must provide an mattermost CLI command")
 	}
 
 	installsForUser, err := p.getInstallationsForUser(extra.UserId)
@@ -25,24 +29,51 @@ func (p *Plugin) runCLICommand(args []string, extra *model.CommandArgs) (*model.
 		return nil, false, err
 	}
 
-	if len(installsForUser) == 0 {
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "No installations found."), false, nil
-	}
-
-	var updatedInstall *cloud.Installation
+	var installToExec *Installation
 	for _, install := range installsForUser {
-		updatedInstall, err = p.cloudClient.GetInstallation(install.ID)
-		if err != nil {
-			p.API.LogError(fmt.Sprintf("could not get updated installation %s", install.ID))
+		if install.OwnerID == extra.UserId && install.Name == name {
+			installToExec = install
+			break
 		}
-
-		install.Installation = *updatedInstall
 	}
 
-	data, err := json.Marshal(installsForUser)
+	if installToExec == nil {
+		return nil, true, fmt.Errorf("no installation with the name %s found", name)
+	}
+
+	output, err := p.execMattermostCLI(installToExec.ID, subcommand)
 	if err != nil {
 		return nil, false, err
 	}
 
-	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, prettyPrintJSON(string(data))), false, nil
+	resp := fmt.Sprintf("Installation: %s\n\nCommand: mattermost %s\n\nResponse:\n%s",
+		installToExec.Name,
+		strings.Join(subcommand, " "),
+		codeBlock(string(output)),
+	)
+
+	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, resp), false, nil
+}
+
+func (p *Plugin) execMattermostCLI(installationID string, subcommand []string) ([]byte, error) {
+	clusterInstallations, err := p.cloudClient.GetClusterInstallations(&cloud.GetClusterInstallationsRequest{
+		InstallationID: installationID,
+		Page:           0,
+		PerPage:        100,
+		IncludeDeleted: false,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get cluster installations")
+	}
+
+	if len(clusterInstallations) == 0 {
+		return nil, fmt.Errorf("no cluster installations found for installation %s", installationID)
+	}
+
+	output, err := p.cloudClient.RunMattermostCLICommandOnClusterInstallation(clusterInstallations[0].ID, subcommand)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
 }

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -15,8 +15,9 @@ import (
 )
 
 type MockClient struct {
-	mockedCloudClusters      []*cloud.Cluster
-	mockedCloudInstallations []*cloud.Installation
+	mockedCloudClusters             []*cloud.Cluster
+	mockedCloudInstallations        []*cloud.Installation
+	mockedCloudClusterInstallations []*cloud.ClusterInstallation
 
 	err error
 }
@@ -43,6 +44,14 @@ func (mc *MockClient) UpgradeInstallation(installataionID, version, license stri
 
 func (mc *MockClient) DeleteInstallation(installationID string) error {
 	return nil
+}
+
+func (mc *MockClient) GetClusterInstallations(request *cloud.GetClusterInstallationsRequest) ([]*cloud.ClusterInstallation, error) {
+	return mc.mockedCloudClusterInstallations, nil
+}
+
+func (mc *MockClient) RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error) {
+	return []byte("mocked command output"), nil
 }
 
 func TestCreateCommand(t *testing.T) {
@@ -178,6 +187,74 @@ func TestUpgradeCommand(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must provide an installation name")
 		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestMattermostCLICommand(t *testing.T) {
+	mockedCloudClient := &MockClient{}
+	plugin := Plugin{cloudClient: mockedCloudClient}
+
+	api := &plugintest.API{}
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	plugin.SetAPI(api)
+
+	ci1 := &cloud.ClusterInstallation{
+		ID: cloud.NewID(),
+	}
+	mockedCloudClient.mockedCloudClusterInstallations = []*cloud.ClusterInstallation{ci1}
+
+	t.Run("run command successfully", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runMattermostCLICommand([]string{"gabesinstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "mocked command output")
+	})
+
+	t.Run("no name provided", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMattermostCLICommand([]string{}, &model.CommandArgs{UserId: "gabeid2"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "must provide an installation name"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+
+		resp, isUserError, err = plugin.runMattermostCLICommand([]string{""}, &model.CommandArgs{UserId: "gabeid2"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "must provide an installation name"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no mattermost subcommand", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runMattermostCLICommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must provide an mattermost CLI command")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+
+		resp, isUserError, err := plugin.runMattermostCLICommand([]string{"gabesinstall2", "version"}, &model.CommandArgs{UserId: "gabeid2"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no installation with the name gabesinstall2 found")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no cluster installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+		mockedCloudClient.mockedCloudClusterInstallations = []*cloud.ClusterInstallation{}
+
+		resp, isUserError, err := plugin.runMattermostCLICommand([]string{"gabesinstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no cluster installations found for installation")
+		assert.False(t, isUserError)
 		assert.Nil(t, resp)
 	})
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -37,6 +37,9 @@ type CloudClient interface {
 	GetInstallations(*cloud.GetInstallationsRequest) ([]*cloud.Installation, error)
 	UpgradeInstallation(installationID, version, license string) error
 	DeleteInstallation(installationID string) error
+
+	GetClusterInstallations(request *cloud.GetClusterInstallationsRequest) ([]*cloud.ClusterInstallation, error)
+	RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error)
 }
 
 // OnActivate runs when the plugin activates and ensures the plugin is properly

--- a/server/utils.go
+++ b/server/utils.go
@@ -19,6 +19,10 @@ func jsonCodeBlock(in string) string {
 	return fmt.Sprintf("``` json\n%s\n```", in)
 }
 
+func codeBlock(in string) string {
+	return fmt.Sprintf("```\n%s\n```", in)
+}
+
 func validLicenseOption(license string) bool {
 	return license == licenseOptionE10 || license == licenseOptionE20
 }

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -8,11 +8,6 @@ class Plugin {
 
         registry.registerPopoverUserAttributesComponent(UserAttribute);
     }
-
-    deinitialize() {
-        //eslint-disable-next-line no-console
-        console.log('Shutting down cloud plugin');
-    }
 }
 
 global.window.registerPlugin(pluginId, new Plugin());


### PR DESCRIPTION
This change does the following:
 - Adds a command to run Mattermost CLI subcommands in installations.
 - Runs `mattermost sampledata` on installations when they are created
   with the --test-data flag.
 - Move webhook handling into a goroutine so that the plugin will
   correctly close the connection to the provisioning server.
 - Minor bug and logging fixes.

https://mattermost.atlassian.net/browse/MM-18519