### PR TITLE
MM-19561 Add ability to install Team Edition through Cloud Plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 govet:
 ifneq ($(HAS_SERVER),)
 	@echo Running govet
-	@# Workaround because you cant install binaries without adding them to go.mod
+	@# Workaround because you cannot install binaries without adding them to go.mod
 	env GO111MODULE=off $(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	$(GO) vet ./...
 	$(GO) vet -vettool=$(GOPATH)/bin/shadow ./...

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 govet:
 ifneq ($(HAS_SERVER),)
 	@echo Running govet
-	@# Workaround because you can't install binaries without adding them to go.mod
+	@# Workaround because you cant install binaries without adding them to go.mod
 	env GO111MODULE=off $(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	$(GO) vet ./...
 	$(GO) vet -vettool=$(GOPATH)/bin/shadow ./...

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -20,7 +20,7 @@ func getCreateFlagSet() *flag.FlagSet {
 	createFlagSet.String("size", "miniSingleton", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
 	createFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
 	createFlagSet.String("affinity", "multitenant", "Whether the installation is isolated in it's own cluster or shares ones. Can be 'isolated' or 'multitenant'")
-	createFlagSet.String("license", "e20", "The enterprise license to use. Can be 'e10' or 'e20'")
+	createFlagSet.String("license", "te", "The enterprise license to use. Can be 'e10', 'e20', or leave blank to choose Team Edition")
 	createFlagSet.Bool("test-data", false, "Set to pre-load the server with test data")
 
 	return createFlagSet
@@ -50,7 +50,7 @@ func parseCreateArgs(args []string, install *Installation) error {
 		return err
 	}
 	if !validLicenseOption(install.License) {
-		return fmt.Errorf("invalid license option %s, must be %s or %s", install.License, licenseOptionE10, licenseOptionE20)
+		return fmt.Errorf("invalid license option %s, must be %s, %s or none", install.License, licenseOptionE10, licenseOptionE20)
 	}
 	install.TestData, err = createFlagSet.GetBool("test-data")
 	if err != nil {
@@ -83,14 +83,22 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 
 	config := p.getConfiguration()
 
-	license := config.E20License
+	license := ""
 	if install.License == licenseOptionE10 {
 		license = config.E10License
+	} else if install.License == licenseOptionE20 {
+		license = config.E20License
 	}
 
 	if install.Version != "" {
 		var exists bool
-		repository := "mattermost/mattermost-enterprise-edition"
+		var repository string
+		if install.License == licenseOptionTE {
+			repository = "mattermost/mattermost-team-edition"
+		} else {
+			repository = "mattermost/mattermost-enterprise-edition"
+		}
+
 		exists, err = p.dockerClient.ValidTag(install.Version, repository)
 		if err != nil {
 			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", repository, install.Version).Error())

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -20,7 +20,7 @@ func getCreateFlagSet() *flag.FlagSet {
 	createFlagSet.String("size", "miniSingleton", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
 	createFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
 	createFlagSet.String("affinity", "multitenant", "Whether the installation is isolated in it's own cluster or shares ones. Can be 'isolated' or 'multitenant'")
-	createFlagSet.String("license", "te", "The enterprise license to use. Can be 'e10', 'e20', or leave blank to choose Team Edition")
+	createFlagSet.String("license", "e20", "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
 	createFlagSet.Bool("test-data", false, "Set to pre-load the server with test data")
 
 	return createFlagSet
@@ -50,7 +50,7 @@ func parseCreateArgs(args []string, install *Installation) error {
 		return err
 	}
 	if !validLicenseOption(install.License) {
-		return fmt.Errorf("invalid license option %s, must be %s, %s or none", install.License, licenseOptionE10, licenseOptionE20)
+		return fmt.Errorf("invalid license option %s, must be %s, %s or %s", install.License, licenseOptionE10, licenseOptionE20, licenseOptionTE)
 	}
 	install.TestData, err = createFlagSet.GetBool("test-data")
 	if err != nil {

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -86,27 +86,13 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 	license := ""
 	if install.License == licenseOptionE10 {
 		license = config.E10License
-		if license == "" {
-			p.API.LogWarn("E10License was empty; applying placeholder.")
-			license = "E10 license placeholder"
-		}
 	} else if install.License == licenseOptionE20 {
 		license = config.E20License
-		if license == "" {
-			p.API.LogWarn("E20License was empty; applying placeholder.")
-			license = "E20 license placeholder"
-		}
 	}
 
 	if install.Version != "" {
 		var exists bool
-		var repository string
-		if install.License == licenseOptionTE {
-			repository = "mattermost/mattermost-team-edition"
-		} else {
-			repository = "mattermost/mattermost-enterprise-edition"
-		}
-
+		repository := "mattermost/mattermost-enterprise-edition"
 		exists, err = p.dockerClient.ValidTag(install.Version, repository)
 		if err != nil {
 			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", repository, install.Version).Error())

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -86,8 +86,16 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 	license := ""
 	if install.License == licenseOptionE10 {
 		license = config.E10License
+		if license == "" {
+			p.API.LogWarn("E10License was empty; applying placeholder.")
+			license = "E10 license placeholder"
+		}
 	} else if install.License == licenseOptionE20 {
 		license = config.E20License
+		if license == "" {
+			p.API.LogWarn("E20License was empty; applying placeholder.")
+			license = "E20 license placeholder"
+		}
 	}
 
 	if install.Version != "" {

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -42,7 +42,7 @@ func parseUpgradeArgs(args []string) (string, string, error) {
 	return version, license, nil
 }
 
-// runUpdagradeCommand requests an upgrade and returns the response, an error, and a boolean set to true if a non-nil error is returned due to user error, and false if the error was caused by something else.
+// runUpgradeCommand requests an upgrade and returns the response, an error, and a boolean set to true if a non-nil error is returned due to user error, and false if the error was caused by something else.
 func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
 	if len(args) == 0 || len(args[0]) == 0 {
 		return nil, true, fmt.Errorf("must provide an installation name")

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -12,7 +12,7 @@ import (
 func getUpgradeFlagSet() *flag.FlagSet {
 	upgradeFlagSet := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	upgradeFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
-	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10' or 'e20' for Enterprise, or 'te' for Team Edition. Leave blank for no change.")
+	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10' or 'e20'")
 
 	return upgradeFlagSet
 }
@@ -88,13 +88,6 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 	if newLicense != "" {
 		if newLicense == licenseOptionE10 {
 			license = config.E10License
-		} else if newLicense == licenseOptionE20 {
-			license = config.E20License
-		} else if newLicense == licenseOptionTE {
-			license = ""
-			repository = "mattermost/mattermost-team-edition"
-		} else {
-			return nil, true, fmt.Errorf("an invalid license option %s was requested", newLicense)
 		}
 	}
 

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -12,7 +12,7 @@ import (
 func getUpgradeFlagSet() *flag.FlagSet {
 	upgradeFlagSet := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	upgradeFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
-	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10' or 'e20'")
+	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10' or 'e20' for Enterprise, or 'te' for Team Edition. Leave blank for no change.")
 
 	return upgradeFlagSet
 }
@@ -36,12 +36,13 @@ func parseUpgradeArgs(args []string) (string, string, error) {
 		return "", "", err
 	}
 	if license != "" && !validLicenseOption(license) {
-		return "", "", fmt.Errorf("invalid license option %s, must be %s or %s", license, licenseOptionE10, licenseOptionE20)
+		return "", "", fmt.Errorf("invalid license option %s, must be %s, %s or %s", license, licenseOptionE10, licenseOptionE20, licenseOptionTE)
 	}
 
 	return version, license, nil
 }
 
+// runUpdagradeCommand requests an upgrade and returns the response, an error, and a boolean set to true if a non-nil error is returned due to user error, and false if the error was caused by something else.
 func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
 	if len(args) == 0 || len(args[0]) == 0 {
 		return nil, true, fmt.Errorf("must provide an installation name")
@@ -85,9 +86,15 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 	// Only change the license if a value was provided.
 	license := installToUpgrade.License
 	if newLicense != "" {
-		license = config.E20License
 		if newLicense == licenseOptionE10 {
 			license = config.E10License
+		} else if newLicense == licenseOptionE20 {
+			license = config.E20License
+		} else if newLicense == licenseOptionTE {
+			license = ""
+			repository = "mattermost/mattermost-team-edition"
+		} else {
+			return nil, true, fmt.Errorf("an invalid license option %s was requested", newLicense)
 		}
 	}
 

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -12,7 +12,7 @@ import (
 func getUpgradeFlagSet() *flag.FlagSet {
 	upgradeFlagSet := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	upgradeFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
-	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10' or 'e20'")
+	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
 
 	return upgradeFlagSet
 }
@@ -36,7 +36,7 @@ func parseUpgradeArgs(args []string) (string, string, error) {
 		return "", "", err
 	}
 	if license != "" && !validLicenseOption(license) {
-		return "", "", fmt.Errorf("invalid license option %s, must be %s, %s or %s", license, licenseOptionE10, licenseOptionE20, licenseOptionTE)
+		return "", "", fmt.Errorf("invalid license option %s; must be %s, %s or %s", license, licenseOptionE10, licenseOptionE20, licenseOptionTE)
 	}
 
 	return version, license, nil
@@ -86,8 +86,11 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 	// Only change the license if a value was provided.
 	license := installToUpgrade.License
 	if newLicense != "" {
+		license = config.E20License
 		if newLicense == licenseOptionE10 {
 			license = config.E10License
+		} else if newLicense == licenseOptionTE {
+			license = ""
 		}
 	}
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -12,6 +12,7 @@ import (
 const (
 	licenseOptionE10 = "e10"
 	licenseOptionE20 = "e20"
+	licenseOptionTE  = "te"
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server

--- a/server/utils.go
+++ b/server/utils.go
@@ -24,7 +24,7 @@ func codeBlock(in string) string {
 }
 
 func validLicenseOption(license string) bool {
-	return license == licenseOptionE10 || license == licenseOptionE20
+	return license == licenseOptionE10 || license == licenseOptionE20 || license == licenseOptionTE
 }
 
 // NewBool returns a pointer to a given bool.


### PR DESCRIPTION
This change will allow users of the Cloud Plugin to install Team Edition Mattermost instances, or to upgrade their installation to a Team Edition instance.

The story specifies "install with no license" but this change will actually pull down the Team Edition image if no license is specified, or if license type "`te`" is specified for an upgrade.

Once complete, resolves [MM-19561](https://mattermost.atlassian.net/browse/MM-19561)