### PR TITLE
Upgrade builds to use go 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/golang:1.12-node
+      - image: circleci/golang:1.13-node
 
 jobs:
   lint:


### PR DESCRIPTION
Same go change and reasoning from https://github.com/mattermost/mattermost-cloud/pull/103

Unblocks https://github.com/mattermost/mattermost-plugin-cloud/pull/24