### PR TITLE
Add cluster and installation webhook alerts

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -68,16 +68,10 @@
                 "default": false
             },
             {
-                "key": "ClusterWebhookAlertsTeam",
-                "display_name": "Cluster Webhook Alerts Team",
+                "key": "ClusterWebhookAlertsChannelID",
+                "display_name": "Cluster Webhook Alerts Channel ID",
                 "type": "text",
-                "help_text": "The team to send cluster webhook alerts to when enabled. This team must exist for alerts to be sent."
-            },
-            {
-                "key": "ClusterWebhookAlertsChannel",
-                "display_name": "Cluster Webhook Alerts Channel",
-                "type": "text",
-                "help_text": "The channel to send cluster webhook alerts to when enabled. This channel must exist for alerts to be sent."
+                "help_text": "The channel ID to send cluster webhook alerts to when enabled. This channel must exist for alerts to be sent."
             },
             {
                 "key": "InstallationWebhookAlertsEnable",
@@ -87,16 +81,10 @@
                 "default": false
             },
             {
-                "key": "InstallationWebhookAlertsTeam",
-                "display_name": "Installation Webhook Alerts Team",
+                "key": "InstallationWebhookAlertsChannelID",
+                "display_name": "Installation Webhook Alerts Channel ID",
                 "type": "text",
-                "help_text": "The team to send installation webhook alerts to when enabled. This team must exist for alerts to be sent."
-            },
-            {
-                "key": "InstallationWebhookAlertsChannel",
-                "display_name": "Installation Webhook Alerts Channel",
-                "type": "text",
-                "help_text": "The channel to send installation webhook alerts to when enabled. This channel must exist for alerts to be sent."
+                "help_text": "The channel ID to send installation webhook alerts to when enabled. This channel must exist for alerts to be sent."
             }
         ]
     }

--- a/plugin.json
+++ b/plugin.json
@@ -59,6 +59,44 @@
                 "display_name": "Email Settings",
                 "type": "longtext",
                 "help_text": "The JSON EmailSettings section for Mattermost."
+            },
+            {
+                "key": "ClusterWebhookAlertsEnable",
+                "display_name": "Enable Cluster Webhook Alerts",
+                "type": "bool",
+                "help_text": "Enable or disable the plugin from sending alerts to the channel defined below when cluster webhooks are received from the provisioner.",
+                "default": false
+            },
+            {
+                "key": "ClusterWebhookAlertsTeam",
+                "display_name": "Cluster Webhook Alerts Team",
+                "type": "text",
+                "help_text": "The team to send cluster webhook alerts to when enabled. This team must exist for alerts to be sent."
+            },
+            {
+                "key": "ClusterWebhookAlertsChannel",
+                "display_name": "Cluster Webhook Alerts Channel",
+                "type": "text",
+                "help_text": "The channel to send cluster webhook alerts to when enabled. This channel must exist for alerts to be sent."
+            },
+            {
+                "key": "InstallationWebhookAlertsEnable",
+                "display_name": "Enable Installation Webhook Alerts",
+                "type": "bool",
+                "help_text": "Enable or disable the plugin from sending alerts to the channel defined below when installation webhooks are received from the provisioner.",
+                "default": false
+            },
+            {
+                "key": "InstallationWebhookAlertsTeam",
+                "display_name": "Installation Webhook Alerts Team",
+                "type": "text",
+                "help_text": "The team to send installation webhook alerts to when enabled. This team must exist for alerts to be sent."
+            },
+            {
+                "key": "InstallationWebhookAlertsChannel",
+                "display_name": "Installation Webhook Alerts Channel",
+                "type": "text",
+                "help_text": "The channel to send installation webhook alerts to when enabled. This channel must exist for alerts to be sent."
             }
         ]
     }

--- a/server/bot.go
+++ b/server/bot.go
@@ -7,7 +7,7 @@ import (
 )
 
 // PostBotDM posts a DM as the cloud bot user.
-func (p *Plugin) PostBotDM(userID string, message string) error {
+func (p *Plugin) PostBotDM(userID, message string) error {
 	channel, appError := p.API.GetDirectChannel(userID, p.BotUserID)
 	if appError != nil {
 		return appError
@@ -23,4 +23,26 @@ func (p *Plugin) PostBotDM(userID string, message string) error {
 	})
 
 	return appError
+}
+
+// PostToChannelByNameForTeamNameAsBot posts a message to the provided team + channel as the bot.
+func (p *Plugin) PostToChannelByNameForTeamNameAsBot(teamName, channelName, message string) error {
+	channel, appError := p.API.GetChannelByNameForTeamName(teamName, channelName, false)
+	if appError != nil {
+		return appError
+	}
+	if channel == nil {
+		return fmt.Errorf("channel %s for team %s is nil", channelName, teamName)
+	}
+
+	_, appError = p.API.CreatePost(&model.Post{
+		UserId:    p.BotUserID,
+		ChannelId: channel.Id,
+		Message:   message,
+	})
+	if appError != nil {
+		return appError
+	}
+
+	return nil
 }

--- a/server/bot.go
+++ b/server/bot.go
@@ -25,19 +25,11 @@ func (p *Plugin) PostBotDM(userID, message string) error {
 	return appError
 }
 
-// PostToChannelByNameForTeamNameAsBot posts a message to the provided team + channel as the bot.
-func (p *Plugin) PostToChannelByNameForTeamNameAsBot(teamName, channelName, message string) error {
-	channel, appError := p.API.GetChannelByNameForTeamName(teamName, channelName, false)
-	if appError != nil {
-		return appError
-	}
-	if channel == nil {
-		return fmt.Errorf("channel %s for team %s is nil", channelName, teamName)
-	}
-
-	_, appError = p.API.CreatePost(&model.Post{
+// PostToChannelByIDAsBot posts a message to the provided channel.
+func (p *Plugin) PostToChannelByIDAsBot(channelID, message string) error {
+	_, appError := p.API.CreatePost(&model.Post{
 		UserId:    p.BotUserID,
-		ChannelId: channel.Id,
+		ChannelId: channelID,
 		Message:   message,
 	})
 	if appError != nil {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -37,6 +37,15 @@ type configuration struct {
 
 	// Email
 	EmailSettings string
+
+	// Webhook Alerts
+	ClusterWebhookAlertsEnable  bool
+	ClusterWebhookAlertsTeam    string
+	ClusterWebhookAlertsChannel string
+
+	InstallationWebhookAlertsEnable  bool
+	InstallationWebhookAlertsTeam    string
+	InstallationWebhookAlertsChannel string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -59,7 +68,25 @@ func (c *configuration) IsValid() error {
 		return fmt.Errorf("must specify InstallationDNS")
 	}
 
-	return err
+	if c.ClusterWebhookAlertsEnable {
+		if len(c.ClusterWebhookAlertsTeam) == 0 {
+			return fmt.Errorf("must specify a cluster alerts team when cluster alerts are enabled")
+		}
+		if len(c.ClusterWebhookAlertsChannel) == 0 {
+			return fmt.Errorf("must specify a cluster alerts channel when cluster alerts are enabled")
+		}
+	}
+
+	if c.InstallationWebhookAlertsEnable {
+		if len(c.InstallationWebhookAlertsTeam) == 0 {
+			return fmt.Errorf("must specify an installation alerts team when installation alerts are enabled")
+		}
+		if len(c.InstallationWebhookAlertsChannel) == 0 {
+			return fmt.Errorf("must specify an installation alerts channel when installation alerts are enabled")
+		}
+	}
+
+	return nil
 }
 
 // getConfiguration retrieves the active configuration under lock, making it safe to use

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -39,13 +39,11 @@ type configuration struct {
 	EmailSettings string
 
 	// Webhook Alerts
-	ClusterWebhookAlertsEnable  bool
-	ClusterWebhookAlertsTeam    string
-	ClusterWebhookAlertsChannel string
+	ClusterWebhookAlertsEnable    bool
+	ClusterWebhookAlertsChannelID string
 
-	InstallationWebhookAlertsEnable  bool
-	InstallationWebhookAlertsTeam    string
-	InstallationWebhookAlertsChannel string
+	InstallationWebhookAlertsEnable    bool
+	InstallationWebhookAlertsChannelID string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -69,20 +67,14 @@ func (c *configuration) IsValid() error {
 	}
 
 	if c.ClusterWebhookAlertsEnable {
-		if len(c.ClusterWebhookAlertsTeam) == 0 {
-			return fmt.Errorf("must specify a cluster alerts team when cluster alerts are enabled")
-		}
-		if len(c.ClusterWebhookAlertsChannel) == 0 {
-			return fmt.Errorf("must specify a cluster alerts channel when cluster alerts are enabled")
+		if len(c.ClusterWebhookAlertsChannelID) == 0 {
+			return fmt.Errorf("must specify a cluster alerts channel ID when cluster alerts are enabled")
 		}
 	}
 
 	if c.InstallationWebhookAlertsEnable {
-		if len(c.InstallationWebhookAlertsTeam) == 0 {
-			return fmt.Errorf("must specify an installation alerts team when installation alerts are enabled")
-		}
-		if len(c.InstallationWebhookAlertsChannel) == 0 {
-			return fmt.Errorf("must specify an installation alerts channel when installation alerts are enabled")
+		if len(c.InstallationWebhookAlertsChannelID) == 0 {
+			return fmt.Errorf("must specify an installation alerts channel ID when installation alerts are enabled")
 		}
 	}
 

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -33,15 +33,11 @@ func TestConfigurationIsValid(t *testing.T) {
 	t.Run("cluster alerts", func(t *testing.T) {
 		config := baseConfiguration
 		config.ClusterWebhookAlertsEnable = true
-		t.Run("no team or channel", func(t *testing.T) {
-			require.Error(t, config.IsValid())
-		})
-		t.Run("no channel", func(t *testing.T) {
-			config.ClusterWebhookAlertsTeam = "team1"
+		t.Run("no channel ID", func(t *testing.T) {
 			require.Error(t, config.IsValid())
 		})
 		t.Run("valid", func(t *testing.T) {
-			config.ClusterWebhookAlertsChannel = "channel1"
+			config.ClusterWebhookAlertsChannelID = "channel1"
 			require.NoError(t, config.IsValid())
 		})
 	})
@@ -49,15 +45,11 @@ func TestConfigurationIsValid(t *testing.T) {
 	t.Run("installation alerts", func(t *testing.T) {
 		config := baseConfiguration
 		config.InstallationWebhookAlertsEnable = true
-		t.Run("no team or channel", func(t *testing.T) {
-			require.Error(t, config.IsValid())
-		})
-		t.Run("no channel", func(t *testing.T) {
-			config.InstallationWebhookAlertsTeam = "team1"
+		t.Run("no channel ID", func(t *testing.T) {
 			require.Error(t, config.IsValid())
 		})
 		t.Run("valid", func(t *testing.T) {
-			config.InstallationWebhookAlertsChannel = "channel1"
+			config.InstallationWebhookAlertsChannelID = "channel1"
 			require.NoError(t, config.IsValid())
 		})
 	})

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurationIsValid(t *testing.T) {
+	baseConfiguration := configuration{
+		ProvisioningServerURL:           "https://provisioner.url.com",
+		InstallationDNS:                 "test.com",
+		ClusterWebhookAlertsEnable:      false,
+		InstallationWebhookAlertsEnable: false,
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, baseConfiguration.IsValid())
+	})
+
+	t.Run("no provisioner url", func(t *testing.T) {
+		config := baseConfiguration
+		config.ProvisioningServerURL = ""
+		require.Error(t, config.IsValid())
+	})
+
+	t.Run("no intallation dns", func(t *testing.T) {
+		config := baseConfiguration
+		config.InstallationDNS = ""
+		require.Error(t, config.IsValid())
+	})
+
+	t.Run("cluster alerts", func(t *testing.T) {
+		config := baseConfiguration
+		config.ClusterWebhookAlertsEnable = true
+		t.Run("no team or channel", func(t *testing.T) {
+			require.Error(t, config.IsValid())
+		})
+		t.Run("no channel", func(t *testing.T) {
+			config.ClusterWebhookAlertsTeam = "team1"
+			require.Error(t, config.IsValid())
+		})
+		t.Run("valid", func(t *testing.T) {
+			config.ClusterWebhookAlertsChannel = "channel1"
+			require.NoError(t, config.IsValid())
+		})
+	})
+
+	t.Run("installation alerts", func(t *testing.T) {
+		config := baseConfiguration
+		config.InstallationWebhookAlertsEnable = true
+		t.Run("no team or channel", func(t *testing.T) {
+			require.Error(t, config.IsValid())
+		})
+		t.Run("no channel", func(t *testing.T) {
+			config.InstallationWebhookAlertsTeam = "team1"
+			require.Error(t, config.IsValid())
+		})
+		t.Run("valid", func(t *testing.T) {
+			config.InstallationWebhookAlertsChannel = "channel1"
+			require.NoError(t, config.IsValid())
+		})
+	})
+}

--- a/server/utils.go
+++ b/server/utils.go
@@ -23,6 +23,10 @@ func codeBlock(in string) string {
 	return fmt.Sprintf("```\n%s\n```", in)
 }
 
+func inlineCode(in string) string {
+	return fmt.Sprintf("`%s`", in)
+}
+
 func validLicenseOption(license string) bool {
 	return license == licenseOptionE10 || license == licenseOptionE20
 }

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -137,7 +137,7 @@ ID: %s
 State: from %s to %s
 `, inlineCode(payload.ID), inlineCode(payload.OldState), inlineCode(payload.NewState))
 
-	return p.PostToChannelByNameForTeamNameAsBot(p.configuration.ClusterWebhookAlertsTeam, p.configuration.ClusterWebhookAlertsChannel, message)
+	return p.PostToChannelByIDAsBot(p.configuration.ClusterWebhookAlertsChannelID, message)
 }
 
 func (p *Plugin) handleInstallationWebhook(payload *cloud.WebhookPayload) error {
@@ -156,7 +156,7 @@ ID: %s
 State: from %s to %s
 `, inlineCode(payload.ID), inlineCode(payload.OldState), inlineCode(payload.NewState))
 
-	return p.PostToChannelByNameForTeamNameAsBot(p.configuration.InstallationWebhookAlertsTeam, p.configuration.InstallationWebhookAlertsChannel, message)
+	return p.PostToChannelByIDAsBot(p.configuration.InstallationWebhookAlertsChannelID, message)
 }
 
 func (p *Plugin) handleProfileImage(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Webhooks received by the plugin can now be sent to specific channels
as messages. This allows members of those channels to stay updated
on these cloud resources.

https://mattermost.atlassian.net/browse/MM-20075