### PR TITLE
MM-17236 Add (now default) ability to use RDS and S3

### DIFF
--- a/server/configuration.go
+++ b/server/configuration.go
@@ -12,6 +12,9 @@ import (
 const (
 	licenseOptionE10 = "e10"
 	licenseOptionE20 = "e20"
+
+	storageOptionAWS      = "cloud"
+	storageOptionOperator = "local"
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -13,8 +13,11 @@ const (
 	licenseOptionE10 = "e10"
 	licenseOptionE20 = "e20"
 
-	storageOptionAWS      = "cloud"
-	storageOptionOperator = "local"
+	databaseOptionRDS      = "aws-rds"
+	databaseOptionOperator = "operator"
+
+	filestoreOptionS3       = "aws-s3"
+	filestoreOptionOperator = "operator"
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server

--- a/server/installation.go
+++ b/server/installation.go
@@ -19,8 +19,9 @@ const (
 // Installation extends the cloud struct of the same name to add additional configuration options
 type Installation struct {
 	cloud.Installation
-	Name     string
-	TestData bool
+	Name        string
+	TestData    bool
+	StorageType string
 }
 
 // ToPrettyJSON will return a JSON string installation with indentation and new lines

--- a/server/installation.go
+++ b/server/installation.go
@@ -19,9 +19,8 @@ const (
 // Installation extends the cloud struct of the same name to add additional configuration options
 type Installation struct {
 	cloud.Installation
-	Name        string
-	TestData    bool
-	StorageType string
+	Name     string
+	TestData bool
 }
 
 // ToPrettyJSON will return a JSON string installation with indentation and new lines

--- a/server/utils.go
+++ b/server/utils.go
@@ -31,8 +31,12 @@ func validLicenseOption(license string) bool {
 	return license == licenseOptionE10 || license == licenseOptionE20
 }
 
-func validStorageOption(storageChoice string) bool {
-	return storageChoice == storageOptionAWS || storageChoice == storageOptionOperator
+func validDatabaseOption(databaseChoice string) bool {
+	return databaseChoice == databaseOptionRDS || databaseChoice == databaseOptionOperator
+}
+
+func validFilestoreOption(filestoreChoice string) bool {
+	return filestoreChoice == filestoreOptionS3 || filestoreChoice == filestoreOptionOperator
 }
 
 // NewBool returns a pointer to a given bool.

--- a/server/utils.go
+++ b/server/utils.go
@@ -31,6 +31,10 @@ func validLicenseOption(license string) bool {
 	return license == licenseOptionE10 || license == licenseOptionE20
 }
 
+func validStorageOption(storageChoice string) bool {
+	return storageChoice == storageOptionAWS || storageChoice == storageOptionOperator
+}
+
 // NewBool returns a pointer to a given bool.
 func NewBool(b bool) *bool { return &b }
 


### PR DESCRIPTION
This change adds the flag `--storage` to the cloud plugin with default value "cloud" and optional value "local". "local" will use the Minio and MySQL Operators for data storage and "cloud" will instead utilize RDS and S3.

A default installation will now produce details similar to the following:

```
{
    "ID": "z333wfbs8jfebmt8cbta5yn1qw",
    "OwnerID": "s35nt9yqb7d93j74wp7shtb8yy",
    "Version": "stable",
    "DNS": "withrds.dev.cloud.mattermost.com",
    "Database": "aws-rds",
    "Filestore": "aws-s3",
    "License": "hidden",
    "Size": "miniSingleton",
    "Affinity": "multitenant",
    "GroupID": null,
    "State": "creation-requested",
    "CreateAt": 1573772049784,
    "DeleteAt": 0,
    "LockAcquiredBy": null,
    "LockAcquiredAt": 0,
    "Name": "withrds",
    "TestData": false,
    "StorageType": "cloud"
}
```

Resolves [MM-17236](https://mattermost.atlassian.net/browse/MM-19776)