### PR TITLE
MM-19543 Force provided names to lowercase for standardization

### DIFF
--- a/server/command_cli.go
+++ b/server/command_cli.go
@@ -14,7 +14,7 @@ func (p *Plugin) runMattermostCLICommand(args []string, extra *model.CommandArgs
 		return nil, true, errors.New("must provide an installation name")
 	}
 
-	name := strings.ToLower(args[0])
+	name := standardizeName(args[0])
 	if name == "" {
 		return nil, true, errors.New("must provide an installation name")
 	}

--- a/server/command_cli.go
+++ b/server/command_cli.go
@@ -14,7 +14,7 @@ func (p *Plugin) runMattermostCLICommand(args []string, extra *model.CommandArgs
 		return nil, true, errors.New("must provide an installation name")
 	}
 
-	name := args[0]
+	name := strings.ToLower(args[0])
 	if name == "" {
 		return nil, true, errors.New("must provide an installation name")
 	}

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -28,7 +28,7 @@ func getCreateFlagSet() *flag.FlagSet {
 	return createFlagSet
 }
 
-// parseCreateArgs is responsible for reading in arguments and basic input validity checking
+// parseCreateArgs is responsible for reading in arguments and basic input validation
 func parseCreateArgs(args []string, install *Installation) error {
 	createFlagSet := getCreateFlagSet()
 	err := createFlagSet.Parse(args)

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -89,7 +89,7 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 	}
 
 	install := &Installation{
-		Name: args[0],
+		Name: strings.ToLower(args[0]),
 	}
 
 	if install.Name == "" || strings.HasPrefix(install.Name, "--") {

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -89,12 +89,13 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 	}
 
 	install := &Installation{
-		Name: strings.ToLower(args[0]),
+		Name: standardizeName(args[0]),
 	}
 
 	if install.Name == "" || strings.HasPrefix(install.Name, "--") {
 		return nil, true, fmt.Errorf("must provide an installation name")
 	}
+
 	if !validInstallationName(install.Name) {
 		return nil, true, fmt.Errorf("installation name %s is invalid: only letters, numbers, and hyphens are permitted", install.Name)
 	}

--- a/server/command_delete.go
+++ b/server/command_delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/mattermost/mattermost-server/model"
+	"strings"
 )
 
 func (p *Plugin) runDeleteCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
@@ -11,7 +12,7 @@ func (p *Plugin) runDeleteCommand(args []string, extra *model.CommandArgs) (*mod
 		return nil, true, fmt.Errorf("must provide an installation name")
 	}
 
-	name := args[0]
+	name := strings.ToLower(args[0])
 
 	installs, _, err := p.getInstallations()
 	if err != nil {

--- a/server/command_delete.go
+++ b/server/command_delete.go
@@ -21,7 +21,7 @@ func (p *Plugin) runDeleteCommand(args []string, extra *model.CommandArgs) (*mod
 
 	var installToDelete *Installation
 	for _, install := range installs {
-		if install.OwnerID == extra.UserId && install.Name == name {
+		if install.OwnerID == extra.UserId && strings.ToLower(install.Name) == name {
 			installToDelete = install
 			break
 		}

--- a/server/command_delete.go
+++ b/server/command_delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/mattermost/mattermost-server/model"
-	"strings"
 )
 
 func (p *Plugin) runDeleteCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
@@ -12,7 +11,7 @@ func (p *Plugin) runDeleteCommand(args []string, extra *model.CommandArgs) (*mod
 		return nil, true, fmt.Errorf("must provide an installation name")
 	}
 
-	name := strings.ToLower(args[0])
+	name := standardizeName(args[0])
 
 	installs, _, err := p.getInstallations()
 	if err != nil {
@@ -21,7 +20,7 @@ func (p *Plugin) runDeleteCommand(args []string, extra *model.CommandArgs) (*mod
 
 	var installToDelete *Installation
 	for _, install := range installs {
-		if install.OwnerID == extra.UserId && strings.ToLower(install.Name) == name {
+		if install.OwnerID == extra.UserId && standardizeName(install.Name) == name {
 			installToDelete = install
 			break
 		}

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -74,6 +74,13 @@ func TestCreateCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, "Installation being created.")
 	})
 
+	t.Run("create installation successfully with capitalized name to show case insensitivity", func(t *testing.T) {
+		resp, isUserError, err := plugin.runCreateCommand([]string{"jOrAmTeSt"}, &model.CommandArgs{})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation being created.")
+	})
+
 	t.Run("docker tag", func(t *testing.T) {
 
 		t.Run("valid", func(t *testing.T) {
@@ -173,6 +180,15 @@ func TestUpgradeCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, "Upgrade of installation")
 	})
 
+	t.Run("upgrade installation successfully with name with caps to demonstrate case insensitivity of name", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runUpgradeCommand([]string{"GabesInstall", "--version", "5.13.1"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Upgrade of installation")
+	})
+
 	t.Run("no version", func(t *testing.T) {
 		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
 
@@ -265,6 +281,15 @@ func TestMattermostCLICommand(t *testing.T) {
 		assert.Contains(t, resp.Text, "mocked command output")
 	})
 
+	t.Run("run command successfully with caps in name to show name is case insensitive", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runMattermostCLICommand([]string{"GabesInstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "mocked command output")
+	})
+
 	t.Run("no name provided", func(t *testing.T) {
 		resp, isUserError, err := plugin.runMattermostCLICommand([]string{}, &model.CommandArgs{UserId: "gabeid2"})
 		require.NotNil(t, err)
@@ -321,6 +346,15 @@ func TestDeleteCommand(t *testing.T) {
 
 	t.Run("delete installation successfully", func(t *testing.T) {
 		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"joramsinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runDeleteCommand([]string{"joramsinstall"}, &model.CommandArgs{UserId: "joramid"})
+		require.Nil(t, err)
+		assert.False(t, isUserError)
+		assert.True(t, strings.Contains(resp.Text, "Installation joramsinstall deleted."))
+	})
+
+	t.Run("delete installation successfully with caps in name to demonstrate name case insensitivity", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"JoramsInstall\"}]"), nil)
 
 		resp, isUserError, err := plugin.runDeleteCommand([]string{"joramsinstall"}, &model.CommandArgs{UserId: "joramid"})
 		require.Nil(t, err)

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-server/model"
@@ -48,7 +49,7 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 		return nil, true, fmt.Errorf("must provide an installation name")
 	}
 
-	name := args[0]
+	name := strings.ToLower(args[0])
 
 	installs, _, err := p.getInstallations()
 	if err != nil {

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-server/model"
@@ -49,7 +48,7 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 		return nil, true, fmt.Errorf("must provide an installation name")
 	}
 
-	name := strings.ToLower(args[0])
+	name := standardizeName(args[0])
 
 	installs, _, err := p.getInstallations()
 	if err != nil {

--- a/server/utils.go
+++ b/server/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 func prettyPrintJSON(in string) string {
@@ -25,6 +26,10 @@ func codeBlock(in string) string {
 
 func inlineCode(in string) string {
 	return fmt.Sprintf("`%s`", in)
+}
+
+func standardizeName(name string) string {
+	return strings.ToLower(name)
 }
 
 func validLicenseOption(license string) bool {


### PR DESCRIPTION
A small change to force names to lowercase as part of input validation in all of the cloud plugin entrypoints that take a name.

Resolves MM-19543