### PR TITLE
Disallow duplicate installation names

### DIFF
--- a/server/command_create.go
+++ b/server/command_create.go
@@ -100,6 +100,13 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		return nil, true, fmt.Errorf("installation name %s is invalid: only letters, numbers, and hyphens are permitted", install.Name)
 	}
 
+	if exists, err := p.installationWithNameExists(install.Name); err != nil || exists {
+		if err != nil {
+			return nil, false, err
+		}
+		return nil, true, fmt.Errorf("Installation name %s already exists. Names are case insensitive and must be unique so you must choose a new name and try again", install.Name)
+	}
+
 	err := parseCreateArgs(args, install)
 	if err != nil {
 		return nil, true, err
@@ -181,6 +188,20 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Installation being created. You will receive a notification when it is ready. Use `/cloud list` to check on the status of your installations.\n\n"+jsonCodeBlock(prettyPrintJSON(string(data)))), false, nil
 }
 
-func validInstallationName(name string) bool {
-	return installationNameMatcher.MatchString(name)
+// installationWithNameExists returns true when there already exists an installation with name "name"
+func (p *Plugin) installationWithNameExists(name string) (bool, error) {
+
+	existing, _, err := p.getInstallations()
+	if err != nil {
+		return false, errors.Wrap(err, "trouble looking up existing installations")
+	}
+
+	for _, i := range existing {
+		// FIXME standardizing these here really shouldn't be necessary if everything is stored in the correct format, but better safe than sorry until we can find a better approach
+		if standardizeName(name) == standardizeName(i.Name) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -100,14 +100,15 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		return nil, true, fmt.Errorf("installation name %s is invalid: only letters, numbers, and hyphens are permitted", install.Name)
 	}
 
-	if exists, err := p.installationWithNameExists(install.Name); err != nil || exists {
+	exists, err := p.installationWithNameExists(install.Name)
+	if err != nil || exists {
 		if err != nil {
 			return nil, false, err
 		}
 		return nil, true, fmt.Errorf("Installation name %s already exists. Names are case insensitive and must be unique so you must choose a new name and try again", install.Name)
 	}
 
-	err := parseCreateArgs(args, install)
+	err = parseCreateArgs(args, install)
 	if err != nil {
 		return nil, true, err
 	}
@@ -190,7 +191,6 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 
 // installationWithNameExists returns true when there already exists an installation with name "name"
 func (p *Plugin) installationWithNameExists(name string) (bool, error) {
-
 	existing, _, err := p.getInstallations()
 	if err != nil {
 		return false, errors.Wrap(err, "trouble looking up existing installations")

--- a/server/command_list.go
+++ b/server/command_list.go
@@ -40,8 +40,7 @@ func (p *Plugin) getUpdatedInstallsForUser(userID string) ([]*Installation, erro
 			return nil, errors.Wrapf(err, "could not get updated installation %s", install.ID)
 		}
 		if updatedInstall == nil {
-			p.API.LogError(fmt.Sprintf("could not find installation %s", install.ID))
-			continue
+			return nil, fmt.Errorf("could not find installation %s", install.ID)
 		}
 		install.Installation = *updatedInstall
 		install.License = "hidden"

--- a/server/command_list.go
+++ b/server/command_list.go
@@ -40,7 +40,8 @@ func (p *Plugin) getUpdatedInstallsForUser(userID string) ([]*Installation, erro
 			return nil, errors.Wrapf(err, "could not get updated installation %s", install.ID)
 		}
 		if updatedInstall == nil {
-			return nil, fmt.Errorf("could not find installation %s", install.ID)
+			p.API.LogError(fmt.Sprintf("could not find installation %s", install.ID))
+			continue
 		}
 		install.Installation = *updatedInstall
 		install.License = "hidden"

--- a/server/installation.go
+++ b/server/installation.go
@@ -161,6 +161,7 @@ func (p *Plugin) deleteInstallation(installationID string) error {
 	return fmt.Errorf("failed %d times to delete installation %s", StoreInstallRetries, installationID)
 }
 
+// getInstallations fetches existing installs from the KV store and returns a slice of pointers to the Installations (unmarshalled from JSON), the original JSON as a byte slice, and any errors
 func (p *Plugin) getInstallations() ([]*Installation, []byte, error) {
 	originalJSONInstalls, err := p.API.KVGet(StoreInstallsKey)
 	if err != nil {

--- a/server/utils.go
+++ b/server/utils.go
@@ -40,6 +40,10 @@ func validDatabaseOption(databaseChoice string) bool {
 	return databaseChoice == databaseOptionRDS || databaseChoice == databaseOptionOperator
 }
 
+func validInstallationName(name string) bool {
+	return installationNameMatcher.MatchString(name)
+}
+
 func validFilestoreOption(filestoreChoice string) bool {
 	return filestoreChoice == filestoreOptionS3 || filestoreChoice == filestoreOptionOperator
 }


### PR DESCRIPTION
This change consists of two commits:

5713088 checks for existing installations with the same name before create is called and produces a user friendly error:

![Screenshot from 2019-11-18 16-57-25](https://user-images.githubusercontent.com/3743903/69101200-9bf75700-0a24-11ea-8145-95c7169b1bfd.png)

6c76fcd corrects a small misbehavior that I discovered when calling `/cloud list`. If an installation is looked up but cannot be found, we want to log the error and `continue` rather than bailing out. This allows for orphaned installations in `cloud.db` to not totally break this command and also allows the output of `list` to be best-effort.
Resolves [MM-19542](https://mattermost.atlassian.net/browse/MM-19542).