### PR TITLE
MM-19560: added logic that allows upgrading license or version separately

### DIFF
--- a/server/command_test.go
+++ b/server/command_test.go
@@ -217,8 +217,16 @@ func TestUpgradeCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, "Upgrade of installation")
 	})
 
-	t.Run("docker tag", func(t *testing.T) {
+	t.Run("version is equal to current version", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\", \"Version\": \"5.31.1\"}]"), nil)
 
+		resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall", "--version", "5.31.1"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Upgrade of installation")
+	})
+
+	t.Run("docker tag", func(t *testing.T) {
 		t.Run("valid", func(t *testing.T) {
 			api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -189,14 +189,32 @@ func TestUpgradeCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, "Upgrade of installation")
 	})
 
-	t.Run("no version", func(t *testing.T) {
+	t.Run("no version and no license", func(t *testing.T) {
 		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
 
 		resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must specify a version")
+		assert.Contains(t, err.Error(), "must specify at least one option: license or version")
 		assert.True(t, isUserError)
 		assert.Nil(t, resp)
+	})
+
+	t.Run("with version and no license", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall", "--version", "5.13.1"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Upgrade of installation")
+	})
+
+	t.Run("with license and no version", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall", "--license", "e10"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Upgrade of installation")
 	})
 
 	t.Run("docker tag", func(t *testing.T) {

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -78,17 +78,17 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 		return nil, true, err
 	}
 
-	// Use the current version if none was provided, otherwise validate that a correspondent image tag exists.
+	// Use the current version if none was provided.
 	if version == "" {
 		version = installToUpgrade.Version
-	} else {
-		exists, err := p.dockerClient.ValidTag(version, dockerRepository)
-		if err != nil {
-			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", dockerRepository, version).Error())
-		}
-		if !exists {
-			return nil, true, fmt.Errorf("%s is not a valid docker tag for repository %s", version, dockerRepository)
-		}
+	}
+
+	exists, err := p.dockerClient.ValidTag(version, dockerRepository)
+	if err != nil {
+		p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", dockerRepository, version).Error())
+	}
+	if !exists {
+		return nil, true, fmt.Errorf("%s is not a valid docker tag for repository %s", version, dockerRepository)
 	}
 
 	config := p.getConfiguration()

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -28,15 +28,17 @@ func parseUpgradeArgs(args []string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	if version == "" {
-		return "", "", errors.New("must specify a version")
-	}
+
 	license, err := upgradeFlagSet.GetString("license")
 	if err != nil {
 		return "", "", err
 	}
 	if license != "" && !validLicenseOption(license) {
 		return "", "", fmt.Errorf("invalid license option %s; must be %s, %s or %s", license, licenseOptionE10, licenseOptionE20, licenseOptionTE)
+	}
+
+	if version == "" && license == "" {
+		return "", "", errors.New("must specify at least one option: license or version")
 	}
 
 	return version, license, nil


### PR DESCRIPTION
This PR changes the backend logic of the upgrade command. Plugin users will now can upgrade `version` or `license` independently or at the same time.

Fixes: https://mattermost.atlassian.net/browse/MM-19560

Signed-off-by: Gabriel Linden Sagula <gsagula@gmail.com>