### PR TITLE
Remove group check on installation creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5
-	github.com/mattermost/mattermost-cloud v0.18.3-0.20200410174526-5785ffd13bf0
+	github.com/mattermost/mattermost-cloud v0.18.3-0.20200422184813-335489fc317a
 	github.com/mattermost/mattermost-server v1.4.1-0.20190926112648-af3ffeed1a4a
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
@@ -654,8 +655,8 @@ github.com/mattermost/gorp v2.0.1-0.20190301154413-3b31e9a39d05+incompatible h1:
 github.com/mattermost/gorp v2.0.1-0.20190301154413-3b31e9a39d05+incompatible/go.mod h1:0kX1qa3DOpaPJyOdMLeo7TcBN0QmUszj9a/VygOhDe0=
 github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN2BZP/PdX23VDU=
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
-github.com/mattermost/mattermost-cloud v0.18.3-0.20200410174526-5785ffd13bf0 h1:OC2nMLTj1Jkc/2fnNZI+KlU6mqhV6qAICqPWT1IiSNs=
-github.com/mattermost/mattermost-cloud v0.18.3-0.20200410174526-5785ffd13bf0/go.mod h1:BYz4EVCdiKAWltIcg+HcYb5nIHEqG0ouTcOXdZVPF2k=
+github.com/mattermost/mattermost-cloud v0.18.3-0.20200422184813-335489fc317a h1:yBdYB1xZxIW8FuZWbGv6iPXtVL59p4MDLc50QOFcnw0=
+github.com/mattermost/mattermost-cloud v0.18.3-0.20200422184813-335489fc317a/go.mod h1:BYz4EVCdiKAWltIcg+HcYb5nIHEqG0ouTcOXdZVPF2k=
 github.com/mattermost/mattermost-operator v1.3.0 h1:q3HSCKyeEm8R1SNJX2n6GzF02GdzsbfItlHC9CEkKEY=
 github.com/mattermost/mattermost-operator v1.3.0/go.mod h1:qZ0P5FBGr9U91b11rYrjzCwFCPWGtqUxBKPga00GLpg=
 github.com/mattermost/mattermost-server v1.4.1-0.20190926112648-af3ffeed1a4a h1:Vq44zXWe1kK6+JpdIbGCbdfv3kjLjfEnxv9aRR5dE9w=

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.cloud",
     "name": "Mattermost Private Cloud",
     "description": "This plugin allows spinning up and down Mattermost installations using Mattermost Private Cloud.",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -160,22 +160,9 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		return nil, false, errors.Errorf("could not determine filestore type; provided filestore type was %s", install.Filestore)
 	}
 
-	var groupID string
-	var group *cloud.Group
-	if len(config.GroupID) != 0 {
-		group, err = p.cloudClient.GetGroup(config.GroupID)
-		if err != nil {
-			return nil, false, errors.Wrapf(err, "unable to get group with ID %s", config.GroupID)
-		}
-		if group == nil {
-			return nil, false, errors.Errorf("group with ID %s does not exist", config.GroupID)
-		}
-		groupID = config.GroupID
-	}
-
 	req := &cloud.CreateInstallationRequest{
 		OwnerID:   extra.UserId,
-		GroupID:   groupID,
+		GroupID:   config.GroupID,
 		Affinity:  install.Affinity,
 		DNS:       fmt.Sprintf("%s.%s", install.Name, config.InstallationDNS),
 		Database:  database,

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "com.mattermost.cloud",
-	Version: "0.1.11",
+	Version: "0.1.12",
 }

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -98,7 +98,8 @@ Installation details:
 		cloud.InstallationStateCreationInProgress,
 		cloud.InstallationStateCreationDNS,
 		cloud.InstallationStateCreationNoCompatibleClusters,
-		cloud.InstallationStateCreationFailed:
+		cloud.InstallationStateCreationFailed,
+		cloud.InstallationStateCreationFinalTasks:
 
 		err = p.setupInstallation(install)
 		if err != nil {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'com.mattermost.cloud';
-export const version = '0.1.11';
+export const version = '0.1.12';


### PR DESCRIPTION
This removes the API call to the provisioner that was originally
used to ensure the group ID was valid. The code worked as intended,
but only served the purpose of providing a cleaner error message
if the group did not exist. A similar error will now be returned
later when the installation creation is attempted.

This change is being made to reduce code complexity and to remove
the requirement for the plugin to hit the `group` API endpoints at
all. This allows for stricter authentication scope if desired.

Also, the plugin now properly handles installation webhooks where
the old state was `creation-final-tasks`.

This also bumps the version number in preparation for cutting a new
release.

https://mattermost.atlassian.net/browse/MM-24566

