### PR TITLE
Add release notify action and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Thank you for contributing a pull request! Here are a few tips to help you:
+
+1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
+2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
+3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
+-->
+
+#### Summary
+<!--
+A description of what this pull request does.
+-->
+
+#### Ticket Link
+<!--
+If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.
+
+  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX
+
+Otherwise, link the JIRA ticket.
+-->
+
+#### Release Note
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+-->
+
+```release-note
+
+```

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,25 @@
+name: notify-release
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - shell: bash
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          REPO=$(echo $GITHUB_CONTEXT | jq -r '.repository')
+          TAGVERSION=$(echo $GITHUB_CONTEXT | jq -r '.event.release.tag_name')
+          TAGURL=$(echo $GITHUB_CONTEXT | jq -r '.event.release.html_url')
+          BODY=$(echo $GITHUB_CONTEXT | jq -r '.event.release.body' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
+
+          echo "{\"username\":\"Cloud Bot Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"text\":\"# **New Release for $REPO** - Release [$TAGVERSION]($TAGURL)\n $BODY\"}" > mattermost.json
+          cat mattermost.json
+
+      - uses: mattermost/action-mattermost-notify@1.0.2
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
#### Summary
 - Adds a pull request template to add the release note section
 - Adds GH Action to post a notification when we have a new release

Webhook set in the secret to post in the `Plugin: Cloud` channel

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
