### PR TITLE
block installations if is less than version 5.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattermost/mattermost-plugin-starter-template
 go 1.13
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5
 	github.com/mattermost/mattermost-cloud v0.19.1-0.20200522160004-a4357c8defe6

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -43,6 +43,7 @@ func parseCreateArgs(args []string, install *Installation) error {
 	if err != nil {
 		return err
 	}
+
 	install.Affinity, err = createFlagSet.GetString("affinity")
 	if err != nil {
 		return err
@@ -135,6 +136,11 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		}
 		if !exists {
 			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, repository)
+		}
+
+		err = validVersionOption(install.Version)
+		if err != nil {
+			return nil, true, err
 		}
 	}
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -91,6 +91,27 @@ func TestCreateCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, "Installation being created.")
 	})
 
+	t.Run("block it try to install version below 5.12.0", func(t *testing.T) {
+		resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--version", "5.8.3"}, &model.CommandArgs{})
+		require.Error(t, err)
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("allow it try to install version greater than 5.12.0", func(t *testing.T) {
+		resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--version", "5.20.1"}, &model.CommandArgs{})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation being created.")
+	})
+
+	t.Run("allow it try to install version called latest", func(t *testing.T) {
+		resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--version", "latest"}, &model.CommandArgs{})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation being created.")
+	})
+
 	t.Run("docker tag", func(t *testing.T) {
 
 		t.Run("valid", func(t *testing.T) {
@@ -109,7 +130,6 @@ func TestCreateCommand(t *testing.T) {
 			assert.True(t, isUserError)
 			assert.Nil(t, resp)
 		})
-
 	})
 
 	t.Run("invalid license", func(t *testing.T) {

--- a/server/utils.go
+++ b/server/utils.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/pkg/errors"
 )
 
 func prettyPrintJSON(in string) string {
@@ -34,6 +37,24 @@ func standardizeName(name string) string {
 
 func validLicenseOption(license string) bool {
 	return license == licenseOptionE10 || license == licenseOptionE20 || license == licenseOptionTE
+}
+
+func validVersionOption(version string) error {
+	v, err := semver.Parse(version)
+	if err != nil {
+		// in case using a non version like latest or any other tag
+		return nil
+	}
+
+	expectedRange, err := semver.ParseRange("< 5.12.0")
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse the version range for %s", version)
+	}
+	if expectedRange(v) {
+		return errors.Errorf("invalid Version option %s, must be greater than 5.12.0", version)
+	}
+
+	return nil
 }
 
 func validDatabaseOption(databaseChoice string) bool {


### PR DESCRIPTION
#### Summary
Block cloud create new test installation if the requested installation have the version less than 5.12.0



#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-26001

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
block installations if is less than version 5.12.0
```
