### PR TITLE
MM-29124 Change the default filestore to non-multitenant on E10/E0

### DIFF
--- a/server/command_create.go
+++ b/server/command_create.go
@@ -20,7 +20,7 @@ func getCreateFlagSet() *flag.FlagSet {
 	createFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
 	createFlagSet.String("affinity", cloud.InstallationAffinityMultiTenant, "Whether the installation is isolated in it's own cluster or shares ones. Can be 'isolated' or 'multitenant'")
 	createFlagSet.String("license", "e20", "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
-	createFlagSet.String("filestore", cloud.InstallationFilestoreMultiTenantAwsS3, "Specify the backing file store. Can be 'aws-multitenant-s3' (S3 Shared Bucket), 'aws-s3' (S3 Bucket), 'operator' (Minio Operator inside the cluster")
+	createFlagSet.String("filestore", "", "Specify the backing file store. Can be 'aws-multitenant-s3' (S3 Shared Bucket), 'aws-s3' (S3 Bucket), 'operator' (Minio Operator inside the cluster. Default 'aws-multi-tenant-s3' for E20, and 'aws-s3' for E10 and E0/TE.")
 	createFlagSet.String("database", cloud.InstallationDatabaseMultiTenantRDSPostgres, "Specify the backing database. Can be 'aws-multitenant-rds-postgres' (RDS Postgres Shared), 'aws-multitenant-rds' (RDS MySQL Shared), 'aws-rds-postgres' (RDS Postgres), 'aws-rds' (RDS MySQL), 'mysql-operator' (MySQL Operator inside the cluster)")
 	createFlagSet.Bool("test-data", false, "Set to pre-load the server with test data")
 
@@ -81,6 +81,15 @@ func parseCreateArgs(args []string, install *Installation) error {
 	install.Filestore, err = createFlagSet.GetString("filestore")
 	if err != nil {
 		return err
+	}
+
+	// the filestore has a different default depending upon the target installation type
+	if install.Filestore == "" {
+		if install.License == "e20" {
+			install.Filestore = cloud.InstallationFilestoreMultiTenantAwsS3
+		} else {
+			install.Filestore = cloud.InstallationFilestoreAwsS3
+		}
 	}
 
 	if !cloud.IsSupportedFilestore(install.Filestore) {

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -19,7 +19,7 @@ func getCreateFlagSet() *flag.FlagSet {
 	createFlagSet.String("size", "miniSingleton", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
 	createFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
 	createFlagSet.String("affinity", cloud.InstallationAffinityMultiTenant, "Whether the installation is isolated in it's own cluster or shares ones. Can be 'isolated' or 'multitenant'")
-	createFlagSet.String("license", "e20", "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
+	createFlagSet.String("license", licenseOptionE20, "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
 	createFlagSet.String("filestore", "", "Specify the backing file store. Can be 'aws-multitenant-s3' (S3 Shared Bucket), 'aws-s3' (S3 Bucket), 'operator' (Minio Operator inside the cluster. Default 'aws-multi-tenant-s3' for E20, and 'aws-s3' for E10 and E0/TE.")
 	createFlagSet.String("database", cloud.InstallationDatabaseMultiTenantRDSPostgres, "Specify the backing database. Can be 'aws-multitenant-rds-postgres' (RDS Postgres Shared), 'aws-multitenant-rds' (RDS MySQL Shared), 'aws-rds-postgres' (RDS Postgres), 'aws-rds' (RDS MySQL), 'mysql-operator' (MySQL Operator inside the cluster)")
 	createFlagSet.Bool("test-data", false, "Set to pre-load the server with test data")
@@ -85,7 +85,7 @@ func parseCreateArgs(args []string, install *Installation) error {
 
 	// the filestore has a different default depending upon the target installation type
 	if install.Filestore == "" {
-		if install.License == "e20" {
+		if install.License == licenseOptionE20 {
 			install.Filestore = cloud.InstallationFilestoreMultiTenantAwsS3
 		} else {
 			install.Filestore = cloud.InstallationFilestoreAwsS3


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Changes the default filestore type to single-tenant for E10 and E0, while leaving the default as multitenant for E20.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-29124
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Single tenant s3 filestore is now the default for E10 and E0 installations
```
