### PR TITLE
MM-31206 Fetch the image digest and use that instead of the tag name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -39,7 +39,7 @@ func parseCreateArgs(args []string, install *Installation) error {
 	if err != nil {
 		return err
 	}
-	install.Version, err = createFlagSet.GetString("version")
+	install.Tag, err = createFlagSet.GetString("version")
 	if err != nil {
 		return err
 	}

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -39,10 +39,12 @@ func parseCreateArgs(args []string, install *Installation) error {
 	if err != nil {
 		return err
 	}
-	install.Tag, err = createFlagSet.GetString("version")
+	install.Version, err = createFlagSet.GetString("version")
 	if err != nil {
 		return err
 	}
+
+	install.Tag = install.Version
 
 	install.Affinity, err = createFlagSet.GetString("affinity")
 	if err != nil {
@@ -153,6 +155,11 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 	}
 
 	if install.Version != "" {
+		err = validVersionOption(install.Version)
+		if err != nil {
+			return nil, true, err
+		}
+
 		var exists bool
 		repository := "mattermost/mattermost-enterprise-edition"
 		exists, err = p.dockerClient.ValidTag(install.Version, repository)
@@ -169,11 +176,6 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
 		}
 		install.Version = digest
-
-		err = validVersionOption(install.Version)
-		if err != nil {
-			return nil, true, err
-		}
 	}
 
 	req := &cloud.CreateInstallationRequest{

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -163,6 +163,12 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, repository)
 		}
 
+		digest, err := p.dockerClient.GetDigestForTag(install.Version, repository)
+		if err != nil {
+			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
+		}
+		install.Version = digest
+
 		err = validVersionOption(install.Version)
 		if err != nil {
 			return nil, true, err

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -163,7 +163,8 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, repository)
 		}
 
-		digest, err := p.dockerClient.GetDigestForTag(install.Version, repository)
+		var digest string
+		digest, err = p.dockerClient.GetDigestForTag(install.Version, repository)
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
 		}

--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -49,7 +49,7 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 		api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
 		api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.Channel{}, nil)
 		api.On("CreatePost", &model.Post{
-			Message: "Cloud installation installation-three has been manually deleted and is now removed from the cloud plugin.\n\n``` json\n{\n\t\"Name\": \"installation-three\",\n\t\"ID\": \"id3\",\n\t\"OwnerID\": \"\",\n\t\"GroupID\": null,\n\t\"Version\": \"\",\n\t\"Image\": \"\",\n\t\"DNS\": \"\",\n\t\"Database\": \"\",\n\t\"Filestore\": \"\",\n\t\"License\": \"hidden\",\n\t\"MattermostEnv\": null,\n\t\"Size\": \"\",\n\t\"Affinity\": \"\",\n\t\"State\": \"deleted\",\n\t\"CreateAt\": 0,\n\t\"DeleteAt\": 0,\n\t\"APISecurityLock\": false,\n\t\"LockAcquiredBy\": null,\n\t\"LockAcquiredAt\": 0,\n\t\"TestData\": false\n}\n```",
+			Message: "Cloud installation installation-three has been manually deleted and is now removed from the cloud plugin.\n\n``` json\n{\n\t\"Name\": \"installation-three\",\n\t\"ID\": \"id3\",\n\t\"OwnerID\": \"\",\n\t\"GroupID\": null,\n\t\"Version\": \"\",\n\t\"Image\": \"\",\n\t\"DNS\": \"\",\n\t\"Database\": \"\",\n\t\"Filestore\": \"\",\n\t\"License\": \"hidden\",\n\t\"MattermostEnv\": null,\n\t\"Size\": \"\",\n\t\"Affinity\": \"\",\n\t\"State\": \"deleted\",\n\t\"CreateAt\": 0,\n\t\"DeleteAt\": 0,\n\t\"APISecurityLock\": false,\n\t\"LockAcquiredBy\": null,\n\t\"LockAcquiredAt\": 0,\n\t\"TestData\": false,\n\t\"Tag\": \"\"\n}\n```",
 		}).Return(nil, nil)
 		api.On("LogWarn", mock.AnythingOfTypeArgument("string")).Return(nil)
 

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -63,7 +63,9 @@ func buildPatchInstallationRequestFromArgs(args []string) (*cloud.PatchInstallat
 	return request, nil
 }
 
-// runUpgradeCommand requests an upgrade and returns the response, an error, and a boolean set to true if a non-nil error is returned due to user error, and false if the error was caused by something else.
+// runUpgradeCommand requests an upgrade and returns the response, an
+// error, and a boolean set to true if a non-nil error is returned due
+// to user error, and false if the error was caused by something else.
 func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
 	if len(args) == 0 || len(args[0]) == 0 {
 		return nil, true, errors.Errorf("must provide an installation name")
@@ -103,6 +105,11 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 		if !exists {
 			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", *request.Version, dockerRepository)
 		}
+		digest, err := p.dockerClient.GetDigestForTag(*request.Version, dockerRepository)
+		if err != nil {
+			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", *request.Version)
+		}
+		request.Version = &digest
 	}
 
 	if request.License != nil {

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -105,7 +105,8 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 		if !exists {
 			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", *request.Version, dockerRepository)
 		}
-		digest, err := p.dockerClient.GetDigestForTag(*request.Version, dockerRepository)
+		var digest string
+		digest, err = p.dockerClient.GetDigestForTag(*request.Version, dockerRepository)
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", *request.Version)
 		}

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -110,6 +110,7 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", *request.Version)
 		}
+		installToUpgrade.Tag = *request.Version
 		request.Version = &digest
 	}
 
@@ -133,6 +134,11 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 	_, err = p.cloudClient.UpdateInstallation(installToUpgrade.ID, request)
 	if err != nil {
 		return nil, false, err
+	}
+
+	err = p.updateInstallation(installToUpgrade)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "failed to store new tag in plugin Installation object")
 	}
 
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Upgrade of installation %s has begun. You will receive a notification when it is ready. Use /cloud list to check on the status of your installations.", name)), false, nil

--- a/server/docker.go
+++ b/server/docker.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+
+	"github.com/docker/distribution/manifest/schema2"
 	"github.com/heroku/docker-registry-client/registry"
+	"github.com/pkg/errors"
 )
 
 const dockerHubURL = "https://registry.hub.docker.com"
@@ -41,4 +46,37 @@ func (dc *DockerClient) ValidTag(desiredTag, repository string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// GetDigestForTag fetches the digest for the image. Sadly, this
+// functionality is not present in the Heroku docker client, which
+// will only get digests for v1 manifests, which contain the wrong
+// digest sum
+func (dc *DockerClient) GetDigestForTag(desiredTag, repository string) (string, error) {
+	resource := fmt.Sprintf("%s/v2/%s/manifests/%s", dc.registryURL, repository, desiredTag)
+	tt := &registry.TokenTransport{
+		Transport: http.DefaultTransport,
+		Username:  dc.username,
+		Password:  dc.password,
+	}
+
+	req, err := http.NewRequest("HEAD", resource, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create request")
+	}
+
+	req.Header.Set("Accept", schema2.MediaTypeManifest)
+	resp, err := tt.RoundTrip(req)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to HEAD manifest registry endpoint")
+	}
+
+	digestHeader, ok := resp.Header["Docker-Content-Digest"]
+	if !ok {
+		return "", errors.New("image digest header was missing")
+	} else if len(digestHeader) < 1 {
+		return "", errors.New("image digest header was empty")
+	}
+
+	return digestHeader[0], nil
 }

--- a/server/docker_test.go
+++ b/server/docker_test.go
@@ -7,3 +7,7 @@ type MockedDockerClient struct {
 func (mc *MockedDockerClient) ValidTag(desiredTag, repository string) (bool, error) {
 	return mc.tagExists, nil
 }
+
+func (mc *MockedDockerClient) GetDigestForTag(desiredTag, repository string) (string, error) {
+	return desiredTag, nil
+}

--- a/server/installation.go
+++ b/server/installation.go
@@ -21,6 +21,7 @@ type Installation struct {
 	Name string
 	cloud.Installation
 	TestData bool
+	Tag      string
 }
 
 // ToPrettyJSON will return a JSON string installation with indentation and new lines

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -48,6 +48,7 @@ type CloudClient interface {
 // DockerClientInterface is the interface for interacting with docker.
 type DockerClientInterface interface {
 	ValidTag(desiredTag, repository string) (bool, error)
+	GetDigestForTag(desiredTag, repository string) (string, error)
 }
 
 // BuildHash is the full git hash of the build.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When specifying a Docker image tag name such as `master` in the Cloud plugin, the fetched image is sometimes stale due to a pull policy of `IfNotPresent` on target clusters. This change adjusts the plugin's behavior to automatically resolve the digest sum of the requested Docker image at pull time, so that when the Installation is requested, the correct Docker image is always fetched.

As an additional benefit, it will now be possible to definitively verify the version of the requested Installation in the response from the plugin inside of Mattermost.

As an example, here is an Installation created from the Docker tag `master` with the following command:
`/cloud create ian-master-123 --version master`

![Screenshot from 2020-12-15 18-48-46](https://user-images.githubusercontent.com/3743903/102290247-3f57bb80-3f06-11eb-8bf1-9f3578cbc966.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-31206

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added improved behavior for creating Installations based on Docker image tag names
```
