### PR TITLE
MM-31169 Periodic reminder about old installations

### DIFF
--- a/server/bot.go
+++ b/server/bot.go
@@ -25,6 +25,29 @@ func (p *Plugin) PostBotDM(userID, message string) error {
 	return appError
 }
 
+// PostUniqueBotDM will post a DM to a user with userID like
+// PostBotDM, but if a unique pendingPostID is specified, the caller
+// may assume that any additional calls with the same ID will be
+// dropped upon receipt by Mattermost
+func (p *Plugin) PostUniqueBotDM(userID, pendingPostID, message string) error {
+	channel, appError := p.API.GetDirectChannel(userID, p.BotUserID)
+	if appError != nil {
+		return appError
+	}
+	if channel == nil {
+		return fmt.Errorf("could not get direct channel for bot and user_id=%s", userID)
+	}
+
+	_, appError = p.API.CreatePost(&model.Post{
+		PendingPostId: pendingPostID,
+		UserId:        p.BotUserID,
+		ChannelId:     channel.Id,
+		Message:       message,
+	})
+
+	return appError
+}
+
 // PostToChannelByIDAsBot posts a message to the provided channel.
 func (p *Plugin) PostToChannelByIDAsBot(channelID, message string) error {
 	_, appError := p.API.CreatePost(&model.Post{

--- a/server/nag.go
+++ b/server/nag.go
@@ -85,7 +85,8 @@ func (p *Plugin) nagUser(user *model.User, installations []*Installation) {
 			creationTimestamp,
 		)
 	}
-	postID := fmt.Sprintf("%s%d", user.Id, time.Now().Unix())
+	month, day, year := time.Now().Date()
+	postID := fmt.Sprintf("%s%s", user.Id, fmt.Sprintf("%d%d%d", month, day, year))
 	p.PostUniqueBotDM(user.Id, postID, message)
 }
 

--- a/server/nag.go
+++ b/server/nag.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+// nagUsersSensibly sends a DM to any users whose installations have
+// been around for at least a day, but only if it's 12:30PM to 1:30PM
+// local time for that user
+func (p *Plugin) nagUsersSensibly() error {
+	installs, _, err := p.getInstallations()
+	if err != nil {
+		return err
+	}
+
+	userInstalls := make(map[string][]*Installation)
+	nowMillis := time.Now().Unix() * 1000
+	year, month, day := time.Now().Date()
+	for _, install := range installs {
+		if nowMillis-install.CreateAt < (time.Hour.Milliseconds() * 24) {
+			continue
+		}
+
+		user, err := p.API.GetUser(install.OwnerID)
+		if err != nil {
+			p.API.LogError(fmt.Sprintf(
+				"found an installation %s claimed by %s but failed to look up that user due to error: %s",
+				install.ID, install.OwnerID, err.Error()))
+			continue
+		}
+		userInstalls[user.Id] = append(userInstalls[user.Id], install)
+	}
+
+	for userID, installs := range userInstalls {
+		user, apperr := p.API.GetUser(userID)
+		if apperr != nil {
+			p.API.LogError("failed to look up user %s due to error: %s", userID, apperr.Error())
+		}
+		tzText := user.GetPreferredTimezone()
+		tz, err := time.LoadLocation(tzText)
+		if err != nil {
+			p.API.LogError(fmt.Sprintf(
+				"failed to parse timezone string %s for user %s", tzText, userID))
+		}
+		noonInTz, err := time.ParseInLocation("3:04pm 1 2 2006", fmt.Sprintf("1:00pm %d %d %d", month, day, year), tz)
+		if err != nil {
+			p.API.LogError(fmt.Sprintf(
+				"failed to create Time object for target time in timezone %s due to error: %s", tz, err.Error()))
+		}
+		if !time.Now().Round(time.Hour).Equal(noonInTz) {
+			continue
+		}
+		p.nagUser(user, installs)
+	}
+	return nil
+}
+
+// nagUser DMs a user to remind them to delete old resources defined
+// by the slice of installations provided
+func (p *Plugin) nagUser(user *model.User, installations []*Installation) {
+	message := fmt.Sprintf("Hello %s,\n\nIt looks like you have one or more Cloud instances which have been running for some time.\nPlease review your list of running Cloud instances and be sure to clean up any you're not using anymore!\n\nThese are the instances that have been around for awhile:\n\n|Name|Creation Time|\n|:----|:----|\n", user.FirstName)
+	for _, installation := range installations {
+		tz, err := time.LoadLocation(user.GetPreferredTimezone())
+		if err != nil {
+			p.API.LogError(fmt.Sprintf(
+				"failed to parse timezone string %s for user %s", user.GetPreferredTimezone(), user.Id))
+		}
+
+		installationLink := fmt.Sprintf("[%s](%s)", installation.Name, installation.DNS)
+		creationTimestamp := time.Unix(installation.CreateAt/1000, (installation.CreateAt%1000)*1000).In(tz).
+			Format("Mon Jan 2 15:04:05 -0700 MST 2006")
+
+		message = fmt.Sprintf("%s|%s|%s|\n",
+			message,
+			installationLink,
+			creationTimestamp,
+		)
+	}
+	p.PostBotDM(user.Id, message)
+}
+
+// periodicallyNagUsersAboutOldInstallations starts a new thread and
+// sleeps until the beginning of the next hour, then calls
+// nagUsersSensibly() and calls it each hour after that, which will
+// nag users about old Installations
+func (p *Plugin) periodicallyNagUsersAboutOldInstallations() {
+	go func() {
+		for {
+			time.Sleep(untilNext(time.Hour))
+			p.nagUsersSensibly()
+		}
+	}()
+}
+
+// untilNext returns the duration until the beginning of the next
+// slice of time, e.g. minute or hour
+func untilNext(duration time.Duration) time.Duration {
+	now := time.Now()
+	t := time.Now().Round(duration)
+	if t.Before(now) {
+		t = now.Add(duration).Round(duration)
+	}
+	return time.Until(t)
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -94,5 +94,6 @@ func (p *Plugin) OnActivate() error {
 
 	p.setCloudClient()
 	p.dockerClient = NewDockerClient()
+	p.periodicallyNagUsersAboutOldInstallations()
 	return p.API.RegisterCommand(getCommand())
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Sends users a nice reminder about Installations that are older than a day, once a day, at 1:00PM local time.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-31169

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added periodic reminders of old Installations
```
