### PR TITLE
Allow the abillity to specify enterprise tag on installation create

### DIFF
--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -49,7 +49,7 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 		api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
 		api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.Channel{}, nil)
 		api.On("CreatePost", &model.Post{
-			Message: "Cloud installation installation-three has been manually deleted and is now removed from the cloud plugin.\n\n``` json\n{\n\t\"Name\": \"installation-three\",\n\t\"ID\": \"id3\",\n\t\"OwnerID\": \"\",\n\t\"GroupID\": null,\n\t\"Version\": \"\",\n\t\"Image\": \"\",\n\t\"DNS\": \"\",\n\t\"Database\": \"\",\n\t\"Filestore\": \"\",\n\t\"License\": \"hidden\",\n\t\"MattermostEnv\": null,\n\t\"Size\": \"\",\n\t\"Affinity\": \"\",\n\t\"State\": \"deleted\",\n\t\"CreateAt\": 0,\n\t\"DeleteAt\": 0,\n\t\"APISecurityLock\": false,\n\t\"LockAcquiredBy\": null,\n\t\"LockAcquiredAt\": 0,\n\t\"TestData\": false,\n\t\"Tag\": \"\"\n}\n```",
+			Message: "Cloud installation installation-three has been manually deleted and is now removed from the cloud plugin.\n\n``` json\n{\n\t\"Name\": \"installation-three\",\n\t\"ID\": \"id3\",\n\t\"OwnerID\": \"\",\n\t\"GroupID\": null,\n\t\"Version\": \"\",\n\t\"Image\": \"\",\n\t\"DNS\": \"\",\n\t\"Database\": \"\",\n\t\"Filestore\": \"\",\n\t\"License\": \"hidden\",\n\t\"MattermostEnv\": null,\n\t\"Size\": \"\",\n\t\"Affinity\": \"\",\n\t\"State\": \"deleted\",\n\t\"CreateAt\": 0,\n\t\"DeleteAt\": 0,\n\t\"APISecurityLock\": false,\n\t\"LockAcquiredBy\": null,\n\t\"LockAcquiredAt\": 0,\n\t\"TestData\": false,\n\t\"Tag\": \"\",\n\t\"EnterpriseTag\": \"\"\n}\n```",
 		}).Return(nil, nil)
 		api.On("LogWarn", mock.AnythingOfTypeArgument("string")).Return(nil)
 

--- a/server/installation.go
+++ b/server/installation.go
@@ -20,8 +20,9 @@ const (
 type Installation struct {
 	Name string
 	cloud.Installation
-	TestData bool
-	Tag      string
+	TestData      bool
+	Tag           string
+	EnterpriseTag string
 }
 
 // ToPrettyJSON will return a JSON string installation with indentation and new lines


### PR DESCRIPTION
#### Summary
In order to be able to create cloud instances by using different versions between server and enterprise. 

Example: We have a PR in a server that has a tag of `mattermost/mattermost-team-edition:69cbba7` that does not change anything on enterprise if we currently do:

```
/cloud create foobar --size miniHA --version mattermost/mattermost-team-edition:69cbba7

// We are getting
Error: mattermost/mattermost-team-edition:69cbba7 is not a valid docker tag for repository mattermost/mattermost-enterprise-edition

Since the enterprise repo is hardcoded to the version that is passed in.
```

This PR decouples the two and gives the ability to build your PR with a mix of the two repos.

#### Ticket Link
N/A

#### Release Note

```release-note
* Adds a new enterprise-tag command argument on installation create
```
