### PR TITLE
Handle version checks with new docker repository options

### DIFF
--- a/server/command_create.go
+++ b/server/command_create.go
@@ -12,7 +12,13 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-var dockerRepoWhitelist = []string{"mattermost/mattermost-enterprise-edition", "mattermost/mm-ee-test", "mattermost/mm-ee-cloud", "mattermost/mm-te", "mattermost/mattermost-team-edition"}
+var dockerRepoWhitelist = []string{
+	"mattermost/mattermost-enterprise-edition",
+	"mattermost/mm-ee-test",
+	"mattermost/mm-ee-cloud",
+	"mattermost/mm-te",
+	"mattermost/mattermost-team-edition",
+}
 var installationNameMatcher = regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
 
 func getCreateFlagSet() *flag.FlagSet {

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -71,7 +71,7 @@ func parseCreateArgs(args []string, install *Installation) error {
 	}
 
 	if !validImageName(install.Image) {
-		return errors.Errorf("invalid image name %s", strings.Join(dockerRepoWhitelist, ", "))
+		return errors.Errorf("invalid image name %s, valid options are %s", install.Image, strings.Join(dockerRepoWhitelist, ", "))
 	}
 
 	install.Database, err = createFlagSet.GetString("database")

--- a/server/command_create_test.go
+++ b/server/command_create_test.go
@@ -196,6 +196,22 @@ func TestCreateCommand(t *testing.T) {
 		})
 	})
 
+	t.Run("image", func(t *testing.T) {
+		t.Run("valid image name", func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--image", "mattermost/mm-ee-test"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation being created.")
+		})
+		t.Run("invalid image name", func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--image", "mattermost/randomimage"}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid image name")
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+	})
+
 	t.Run("missing installation name", func(t *testing.T) {
 		resp, isUserError, err := plugin.runCreateCommand([]string{""}, &model.CommandArgs{})
 		require.Error(t, err)

--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -27,7 +27,6 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 						State: cloud.InstallationStateStable,
 					},
 				},
-<<<<<<< HEAD
 				{
 					Installation: &cloud.Installation{
 						ID:    "id2",
@@ -42,22 +41,6 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 				},
 				{
 					Installation: &cloud.Installation{
-=======
-				{
-					Installation: &cloud.Installation{
-						ID:    "id2",
-						State: cloud.InstallationStateStable,
-					},
-				},
-				{
-					Installation: &cloud.Installation{
-						ID:    "id4",
-						State: cloud.InstallationStateStable,
-					},
-				},
-				{
-					Installation: &cloud.Installation{
->>>>>>> importcmd
 						ID:    "id5",
 						State: cloud.InstallationStateStable,
 					},

--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -27,6 +27,7 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 						State: cloud.InstallationStateStable,
 					},
 				},
+<<<<<<< HEAD
 				{
 					Installation: &cloud.Installation{
 						ID:    "id2",
@@ -41,6 +42,22 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 				},
 				{
 					Installation: &cloud.Installation{
+=======
+				{
+					Installation: &cloud.Installation{
+						ID:    "id2",
+						State: cloud.InstallationStateStable,
+					},
+				},
+				{
+					Installation: &cloud.Installation{
+						ID:    "id4",
+						State: cloud.InstallationStateStable,
+					},
+				},
+				{
+					Installation: &cloud.Installation{
+>>>>>>> importcmd
 						ID:    "id5",
 						State: cloud.InstallationStateStable,
 					},

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -10,9 +10,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-const (
-	dockerRepository = "mattermost/mattermost-enterprise-edition"
-)
+var dockerRepository = "mattermost/mattermost-enterprise-edition"
 
 func getUpgradeFlagSet() *flag.FlagSet {
 	upgradeFlagSet := flag.NewFlagSet("upgrade", flag.ContinueOnError)
@@ -55,6 +53,7 @@ func buildPatchInstallationRequestFromArgs(args []string) (*cloud.PatchInstallat
 	if image != "" && !validImageName(image) {
 		return nil, errors.Errorf("invalid image name %s, valid options are %s", image, strings.Join(dockerRepoWhitelist, ", "))
 	}
+	dockerRepository = image
 
 	request := &cloud.PatchInstallationRequest{}
 	if version != "" {

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-server/model"
@@ -18,7 +19,7 @@ func getUpgradeFlagSet() *flag.FlagSet {
 	upgradeFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
 	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
 	upgradeFlagSet.String("size", "", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
-
+	upgradeFlagSet.String("image", "", fmt.Sprintf("Docker image repository, can be %s", strings.Join(dockerRepoWhitelist, ", ")))
 	return upgradeFlagSet
 }
 
@@ -41,12 +42,18 @@ func buildPatchInstallationRequestFromArgs(args []string) (*cloud.PatchInstallat
 	if err != nil {
 		return nil, err
 	}
-
-	if version == "" && license == "" && size == "" {
-		return nil, errors.New("must specify at least one option: version, license, or size")
+	image, err := upgradeFlagSet.GetString("image")
+	if err != nil {
+		return nil, err
+	}
+	if version == "" && license == "" && size == "" && image == "" {
+		return nil, errors.New("must specify at least one option: version, license, image or size")
 	}
 	if license != "" && !validLicenseOption(license) {
 		return nil, errors.Errorf("invalid license option %s; must be %s, %s or %s", license, licenseOptionE10, licenseOptionE20, licenseOptionTE)
+	}
+	if image != "" && !validImageName(image) {
+		return nil, errors.Errorf("invalid image name %s", strings.Join(dockerRepoWhitelist, ", "))
 	}
 
 	request := &cloud.PatchInstallationRequest{}
@@ -58,6 +65,9 @@ func buildPatchInstallationRequestFromArgs(args []string) (*cloud.PatchInstallat
 	}
 	if size != "" {
 		request.Size = &size
+	}
+	if image != "" {
+		request.Image = &image
 	}
 
 	return request, nil

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -53,7 +53,7 @@ func buildPatchInstallationRequestFromArgs(args []string) (*cloud.PatchInstallat
 		return nil, errors.Errorf("invalid license option %s; must be %s, %s or %s", license, licenseOptionE10, licenseOptionE20, licenseOptionTE)
 	}
 	if image != "" && !validImageName(image) {
-		return nil, errors.Errorf("invalid image name %s", strings.Join(dockerRepoWhitelist, ", "))
+		return nil, errors.Errorf("invalid image name %s, valid options are %s", image, strings.Join(dockerRepoWhitelist, ", "))
 	}
 
 	request := &cloud.PatchInstallationRequest{}

--- a/server/command_upgrade_test.go
+++ b/server/command_upgrade_test.go
@@ -45,7 +45,7 @@ func TestUpgradeCommand(t *testing.T) {
 
 		resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must specify at least one option: version, license, or size")
+		assert.Contains(t, err.Error(), "must specify at least one option: version, license, image or size")
 		assert.True(t, isUserError)
 		assert.Nil(t, resp)
 	})
@@ -164,4 +164,24 @@ func TestUpgradeCommand(t *testing.T) {
 		assert.True(t, isUserError)
 		assert.Nil(t, resp)
 	})
+
+	t.Run("image", func(t *testing.T) {
+
+		t.Run("invalid image", func(t *testing.T) {
+			api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+			resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall", "--image", "mattermost/randomimage"}, &model.CommandArgs{UserId: "gabeid"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid image name")
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+		t.Run("valid image", func(t *testing.T) {
+			api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+			resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall", "--image", "mattermost/mm-ee-test"}, &model.CommandArgs{UserId: "gabeid"})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Upgrade of installation")
+		})
+	})
+
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -12,6 +12,7 @@ const (
 	licenseOptionE10 = "e10"
 	licenseOptionE20 = "e20"
 	licenseOptionTE  = "te"
+	defaultImage     = "mattermost/mattermost-enterprise-edition"
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server


### PR DESCRIPTION
#### Summary

Allow to upgrade your installation image and version at the same time, currently you can only use `mattermost/mattermost-enterprise-edition'.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-33307

#### Release Note

```
fix for upgrade command when using version and image

```
