### PR TITLE
Cloud Plugin: handle version checks with new docker repository options

### DIFF
--- a/server/command_create.go
+++ b/server/command_create.go
@@ -170,24 +170,24 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		license = config.E20License
 	}
 
-	if install.Version != "" {
+	if install.Version != "" || install.Image != "" {
 		err = validVersionOption(install.Version)
 		if err != nil {
 			return nil, true, err
 		}
 
 		var exists bool
-		repository := "mattermost/mattermost-enterprise-edition"
-		exists, err = p.dockerClient.ValidTag(install.Version, repository)
+
+		exists, err = p.dockerClient.ValidTag(install.Version, install.Image)
 		if err != nil {
-			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", repository, install.Version).Error())
+			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", install.Image, install.Version).Error())
 		}
 		if !exists {
-			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, repository)
+			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, install.Image)
 		}
 
 		var digest string
-		digest, err = p.dockerClient.GetDigestForTag(install.Version, repository)
+		digest, err = p.dockerClient.GetDigestForTag(install.Version, install.Image)
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
 		}

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -10,9 +10,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-const (
-	dockerRepository = "mattermost/mattermost-enterprise-edition"
-)
+var dockerRepository = "mattermost/mattermost-enterprise-edition"
 
 func getUpgradeFlagSet() *flag.FlagSet {
 	upgradeFlagSet := flag.NewFlagSet("upgrade", flag.ContinueOnError)
@@ -55,6 +53,7 @@ func buildPatchInstallationRequestFromArgs(args []string) (*cloud.PatchInstallat
 	if image != "" && !validImageName(image) {
 		return nil, errors.Errorf("invalid image name %s, valid options are %s", image, strings.Join(dockerRepoWhitelist, ", "))
 	}
+	dockerRepository = image
 
 	request := &cloud.PatchInstallationRequest{}
 	if version != "" {


### PR DESCRIPTION
#### Summary

Allow to upgrade your installation image and version at the same time, currently you can only use `mattermost/mattermost-enterprise-edition'.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-33307

#### Release Note

```release-note
Fixed upgrade command when version and image specified 
```


