### PR TITLE
Add test to import command to see if installation has already been imported

### DIFF
--- a/server/command_create.go
+++ b/server/command_create.go
@@ -172,7 +172,7 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 
 	err = validVersionOption(install.Version)
 	if err != nil {
-		return nil, true, err
+		return nil, true, errors.Wrap(err, "Invalid version number")
 	}
 
 	validTag, err := p.dockerClient.ValidTag(install.Version, install.Image)

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -180,7 +180,7 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", install.Image, install.Version).Error())
 	}
 	if !validTag {
-		return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, install.Image)
+		return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s\n\n Review valid tags at: https://hub.docker.com/r/%s/tags?page=1&ordering=last_updated", install.Version, install.Image, install.Image)
 	}
 
 	var digest string

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -24,7 +24,7 @@ var installationNameMatcher = regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
 func getCreateFlagSet() *flag.FlagSet {
 	createFlagSet := flag.NewFlagSet("create", flag.ContinueOnError)
 	createFlagSet.String("size", "miniSingleton", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
-	createFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
+	createFlagSet.String("version", "latest", "Mattermost version to run, e.g. '5.12.4'")
 	createFlagSet.String("affinity", cloud.InstallationAffinityMultiTenant, "Whether the installation is isolated in it's own cluster or shares ones. Can be 'isolated' or 'multitenant'")
 	createFlagSet.String("license", licenseOptionE20, "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
 	createFlagSet.String("filestore", "", "Specify the backing file store. Can be 'aws-multitenant-s3' (S3 Shared Bucket), 'aws-s3' (S3 Bucket), 'operator' (Minio Operator inside the cluster. Default 'aws-multi-tenant-s3' for E20, and 'aws-s3' for E10 and E0/TE.")
@@ -170,29 +170,25 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		license = config.E20License
 	}
 
-	if install.Version != "" || install.Image != "" {
-		err = validVersionOption(install.Version)
-		if err != nil {
-			return nil, true, err
-		}
-
-		var exists bool
-
-		exists, err = p.dockerClient.ValidTag(install.Version, install.Image)
-		if err != nil {
-			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", install.Image, install.Version).Error())
-		}
-		if !exists {
-			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, install.Image)
-		}
-
-		var digest string
-		digest, err = p.dockerClient.GetDigestForTag(install.Version, install.Image)
-		if err != nil {
-			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
-		}
-		install.Version = digest
+	err = validVersionOption(install.Version)
+	if err != nil {
+		return nil, true, err
 	}
+
+	validTag, err := p.dockerClient.ValidTag(install.Version, install.Image)
+	if err != nil {
+		p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", install.Image, install.Version).Error())
+	}
+	if !validTag {
+		return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, install.Image)
+	}
+
+	var digest string
+	digest, err = p.dockerClient.GetDigestForTag(install.Version, install.Image)
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
+	}
+	install.Version = digest
 
 	req := &cloud.CreateInstallationRequest{
 		OwnerID:   extra.UserId,

--- a/server/command_import.go
+++ b/server/command_import.go
@@ -24,6 +24,7 @@ func (p *Plugin) runImportCommand(args []string, extra *model.CommandArgs) (*mod
 	hostname := u.Hostname()
 
 	if hostname == "" {
+		//if the initiall DNS does not contain HTTP/HTTPS Hostname() will return an empty string so we use the initial DNS instead
 		hostname = installationDNS
 	}
 

--- a/server/command_import.go
+++ b/server/command_import.go
@@ -24,7 +24,7 @@ func (p *Plugin) runImportCommand(args []string, extra *model.CommandArgs) (*mod
 	hostname := u.Hostname()
 
 	if hostname == "" {
-		//if the initiall DNS does not contain HTTP/HTTPS Hostname() will return an empty string so we use the initial DNS instead
+		// If the initial DNS does not contain HTTP/HTTPS Hostname() will return an empty string so we use the initial DNS instead
 		hostname = installationDNS
 	}
 

--- a/server/command_import_test.go
+++ b/server/command_import_test.go
@@ -79,45 +79,46 @@ func TestImport(t *testing.T) {
 
 		})
 	})
+	t.Run("URL with https/https and queries", func(t *testing.T) {
+		t.Run("get import successfully from valid https DNS", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"https://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
 
-	t.Run("get import successfully from valid https DNS", func(t *testing.T) {
-		resp, isUserError, err := plugin.runImportCommand([]string{"https://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
-		require.NoError(t, err)
-		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, "Installation imported")
-	})
+		t.Run("Bad https value", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{" https://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "error parsing url")
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+		t.Run("get import successfully from valid http DNS", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"http://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
 
-	t.Run("Bad https value", func(t *testing.T) {
-		resp, isUserError, err := plugin.runImportCommand([]string{" https://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "error parsing url")
-		assert.True(t, isUserError)
-		assert.Nil(t, resp)
-	})
-	t.Run("get import successfully from valid http DNS", func(t *testing.T) {
-		resp, isUserError, err := plugin.runImportCommand([]string{"http://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
-		require.NoError(t, err)
-		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, "Installation imported")
-	})
-
-	t.Run("Bad http value", func(t *testing.T) {
-		resp, isUserError, err := plugin.runImportCommand([]string{" http://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "error parsing url")
-		assert.True(t, isUserError)
-		assert.Nil(t, resp)
-	})
-	t.Run("get import successfully from http url with query parameters", func(t *testing.T) {
-		resp, isUserError, err := plugin.runImportCommand([]string{"http://import-me.dev.cloud.mattermost.com/api/v1/ping?q=v2"}, &model.CommandArgs{})
-		require.NoError(t, err)
-		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, "Installation imported")
-	})
-	t.Run("get import successfully from https url with query parameters", func(t *testing.T) {
-		resp, isUserError, err := plugin.runImportCommand([]string{"https://import-me.dev.cloud.mattermost.com/api/v1/ping?q=v2"}, &model.CommandArgs{})
-		require.NoError(t, err)
-		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, "Installation imported")
+		t.Run("Bad http value", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{" http://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "error parsing url")
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+		t.Run("get import successfully from http url with query parameters", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"http://import-me.dev.cloud.mattermost.com/api/v1/ping?q=v2"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
+		t.Run("get import successfully from https url with query parameters", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"https://import-me.dev.cloud.mattermost.com/api/v1/ping?q=v2"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
 	})
 }

--- a/server/command_import_test.go
+++ b/server/command_import_test.go
@@ -77,4 +77,48 @@ func TestImport(t *testing.T) {
 		assert.Nil(t, resp)
 
 	})
+	t.Run("http/https testing", func(t *testing.T) {
+
+		t.Run("get import successfully from valid https DNS", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"https://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
+
+		t.Run("Bad https value", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{" https://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "error parsing url")
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+		t.Run("get import successfully from valid http DNS", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"http://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
+
+		t.Run("Bad http value", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{" http://import-me.dev.cloud.mattermost.com"}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "error parsing url")
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+		t.Run("get import successfully from http url with query parameters", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"http://import-me.dev.cloud.mattermost.com/api/v1/ping?q=v2"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
+		t.Run("get import successfully from https url with query parameters", func(t *testing.T) {
+			resp, isUserError, err := plugin.runImportCommand([]string{"https://import-me.dev.cloud.mattermost.com/api/v1/ping?q=v2"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation imported")
+		})
+	})
+
 }

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -45,6 +45,9 @@ func (mc *MockClient) GetInstallationByDNS(DNS string, request *cloud.GetInstall
 	if mc.returnDNSErrorOverride != nil {
 		return nil, mc.returnDNSErrorOverride
 	}
+	if mc.overrideGetInstallationDTO != nil {
+		return mc.overrideGetInstallationDTO, nil
+	}
 
 	return &cloud.InstallationDTO{Installation: &cloud.Installation{ID: "someid", DNS: DNS}}, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add functionality to the cloud plugin for importing installations created from other sources to be managed by the cloud plugin.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-33635

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Additional testing for import command
```
