### PR TITLE
Fix several bit-rot related problems and better `latest` behavior

### DIFF
--- a/server/command_create.go
+++ b/server/command_create.go
@@ -310,7 +310,7 @@ func (p *Plugin) githubLatestVersion() (string, error) {
 
 	for _, release := range grm {
 		if release.TagName == "" {
-			return "", errors.New("tag name was empty in response from GitHub")
+			continue
 		}
 		currentTag := strings.TrimPrefix(release.TagName, "v")
 		currentTagVersion, err := semver.Parse(currentTag)

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -286,6 +286,7 @@ func (p *Plugin) githubLatestVersion() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to find latest release from GitHub")
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", errors.Errorf("got unexpected status code %d while determining latest release from GitHub", resp.StatusCode)

--- a/server/command_create_test.go
+++ b/server/command_create_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/blang/semver/v4"
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
@@ -24,6 +25,14 @@ func TestCreateCommand(t *testing.T) {
 	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
 
 	plugin.SetAPI(api)
+
+	t.Run("ensure latest version lookup routine still works", func(t *testing.T) {
+		latest, err := plugin.githubLatestVersion()
+		require.NoError(t, err)
+		assert.NotEmpty(t, latest)
+		_, err = semver.Parse(latest)
+		assert.NoError(t, err)
+	})
 
 	t.Run("create installation successfully", func(t *testing.T) {
 		resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest"}, &model.CommandArgs{})

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -22,6 +22,10 @@ type MockClient struct {
 	err error
 }
 
+func (mc *MockClient) ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error) {
+	return []byte{}, nil
+}
+
 func (mc *MockClient) GetClusters(request *cloud.GetClustersRequest) ([]*cloud.ClusterDTO, error) {
 	return mc.mockedCloudClustersDTO, mc.err
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -90,7 +90,7 @@ func (p *Plugin) OnActivate() error {
 			return errors.Wrap(err, "failed to determine existing bot ID by username")
 		}
 		if !user.IsBot {
-			return errors.New("found existing user with Cloud Bot username, but the user is not a bot! Cannot continue..")
+			return errors.New("found existing user with Cloud Bot username, but the user is not a bot! Cannot continue")
 		}
 		bot, err = p.API.GetBot(user.Id, false)
 		if err != nil {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -62,6 +63,9 @@ var BuildHashShort string
 // BuildDate is the build date of the build.
 var BuildDate string
 
+// cloud is the username (not display name) of the Cloud Bot. TODO: make this configurable?
+const botName string = "cloud"
+
 // OnActivate runs when the plugin activates and ensures the plugin is properly
 // configured.
 func (p *Plugin) OnActivate() error {
@@ -70,14 +74,33 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
-	bot, apperr := p.API.CreateBot(&model.Bot{
-		Username:    "cloud",
+	bot, appErr := p.API.CreateBot(&model.Bot{
+		Username:    botName,
 		DisplayName: "Cloud",
 		Description: "Created by the Mattermost Private Cloud plugin.",
 	})
-	if apperr != nil {
-		return errors.Wrap(apperr, "failed to ensure github bot")
+
+	if appErr != nil {
+		if !strings.Contains(appErr.Error(), "account with that username already exists") {
+			return errors.Wrap(appErr, "failed to ensure Cloud bot")
+		}
+		user, err := p.API.GetUserByUsername(botName)
+		if err != nil {
+			return errors.Wrap(err, "failed to determine existing bot ID by username")
+		}
+		if !user.IsBot {
+			return errors.New("found existing user with Cloud Bot username, but the user is not a bot! Cannot continue..")
+		}
+		bot, err = p.API.GetBot(user.Id, false)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get bot user ID %s", user.Id)
+		}
 	}
+
+	if bot == nil {
+		return errors.New("still failed to ensure bot after trying everything, but no errors were reported by the process")
+	}
+
 	botID := bot.UserId
 	p.BotUserID = botID
 
@@ -91,7 +114,7 @@ func (p *Plugin) OnActivate() error {
 		return errors.Wrap(err, "couldn't read profile image")
 	}
 
-	appErr := p.API.SetProfileImage(botID, profileImage)
+	appErr = p.API.SetProfileImage(botID, profileImage)
 	if appErr != nil {
 		return errors.Wrap(appErr, "couldn't set profile image")
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -27,6 +27,8 @@ type Plugin struct {
 	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
 	configuration *configuration
+
+	latestMattermostVersion *latestMattermostVersionCache
 }
 
 // CloudClient is the interface for managing cloud installations.

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -44,6 +44,7 @@ type CloudClient interface {
 
 	GetClusterInstallations(request *cloud.GetClusterInstallationsRequest) ([]*cloud.ClusterInstallation, error)
 	RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error)
+	ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error)
 
 	GetGroup(groupID string) (*cloud.Group, error)
 }

--- a/server/setup.go
+++ b/server/setup.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/blang/semver/v4"
+	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 )
@@ -119,17 +121,54 @@ func (p *Plugin) createTestData(client *model.Client4, install *Installation) er
 		return nil
 	}
 
-	_, err := p.execMattermostCLI(install.ID, []string{"sampledata"})
+	mmReleaseVersion, err := semver.Parse(install.Tag)
 	if err != nil {
-		// This probably won't complete before the AWS API Gateway timeout so
-		// log and move on.
+		return errors.Wrapf(err, "failed to parse version %s", install.Tag)
+	}
+
+	if mmReleaseVersion.LT(semver.MustParse("6.0.0")) {
+		_, err := p.execMattermostCLI(install.ID, []string{"sampledata"})
+		if err != nil {
+			// This probably won't complete before the AWS API Gateway timeout so
+			// log and move on.
+			p.API.LogWarn(errors.Wrapf(err, "Unable to finish generating test data for cloud installation %s", install.Name).Error())
+		}
+
+		// Test data generation overrides the sysadmin password, so need to reset
+		_, err = p.execMattermostCLI(install.ID, []string{"user", "password", defaultAdminUsername, defaultAdminPassword})
+		if err != nil {
+			return errors.Wrap(err, "failed to reset sysadmin password back to the default")
+		}
+
+		return nil
+	}
+
+	clusterInstallations, err := p.cloudClient.GetClusterInstallations(
+		&cloud.GetClusterInstallationsRequest{
+			// any single CI will do, so only fetch one
+			Paging:         cloud.AllPagesNotDeleted(),
+			InstallationID: install.ID,
+		})
+	if err != nil {
+		return errors.Wrap(err, "failed to get ClusterInstallations for Installation")
+	}
+	if len(clusterInstallations) != 1 {
+		return errors.Errorf("got unexpected number of ClusterInstallations (%d)", len(clusterInstallations))
+	}
+
+	_, err = p.cloudClient.ExecClusterInstallationCLI(clusterInstallations[0].ID,
+		"mmctl", []string{"--local", "sampledata"})
+	if err != nil {
+		// Gabe thinks this might not complete before the AWS API Gateway timeout so
+		// log and move on the same as we do for versions previous to 6.0, seen earlier in this method.
 		p.API.LogWarn(errors.Wrapf(err, "Unable to finish generating test data for cloud installation %s", install.Name).Error())
 	}
 
-	// Test data generation overrides the sysadmin password, so need to reset
-	_, err = p.execMattermostCLI(install.ID, []string{"user", "password", defaultAdminUsername, defaultAdminPassword})
+	// Test data generation overrides the sysadmin password, so need to reset (using mmctl)
+	_, err = p.cloudClient.ExecClusterInstallationCLI(clusterInstallations[0].ID,
+		"mmctl", []string{"--local", "user", "change-password", defaultAdminUsername, "--password", defaultAdminPassword})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to reset sysadmin password back to the default")
 	}
 
 	return nil

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -163,7 +163,10 @@ ID: %s
 DNS: %s
 ClusterID: %s
 State: from %s to %s
-`, inlineCode(payload.ID), inlineCode(payload.ExtraData["DNS"]), inlineCode(payload.ExtraData["ClusterID"]), inlineCode(payload.OldState), inlineCode(payload.NewState))
+`, inlineCode(payload.ID),
+		inlineCode(payload.ExtraData["DNS"]),
+		inlineCode(payload.ExtraData["ClusterID"]),
+		inlineCode(payload.OldState), inlineCode(payload.NewState))
 
 	return p.PostToChannelByIDAsBot(p.configuration.InstallationWebhookAlertsChannelID, message)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fixes a number of interrelated problems in the Cloud Plugin that have largely been caused by version drift in the main product:
1. `--test-data` flag was broken in versions of Mattermost >6.0. This is fixed.
2. Specifying `latest` version of Mattermost used to get you the hardcoded version in the Operator, which is often a little old. Plugin behavior altered to fetch releases from GitHub and uses the one with the latest version, as determined using semver comparisons. Bonus! Instead of saying `latest` the Tag field in the output from the bot will show the derived version of Mattermost, for fewer surprises for users.
3. Plugin used to fail to start if the Cloud Bot user already existed. This is fixed.

My apologies for making multiple large changes in this PR, but unfortunately they were heavily interrelated changes. The restart bug I just found along the way, during testing.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Resolves:
https://mattermost.atlassian.net/browse/MM-40193
https://mattermost.atlassian.net/browse/MM-39779
https://mattermost.atlassian.net/browse/MM-39801

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fixed --test-data flag for post-6.0 Mattermost versions
Updated "latest" version behavior to track latest stable version on GitHub instead of relying on the Operator's hardcoded version
Fixed bug causing plugin to fail to restart
```
