### PR TITLE
Loosen bot existence check to pass if email already exists, too

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -82,7 +82,7 @@ func (p *Plugin) OnActivate() error {
 	})
 
 	if appErr != nil {
-		if !strings.Contains(appErr.Error(), "account with that username already exists") {
+		if !strings.Contains(appErr.Error(), "already exists") {
 			return errors.Wrap(appErr, "failed to ensure Cloud bot")
 		}
 		user, err := p.API.GetUserByUsername(botName)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When calling EnsureBot, if the bot already exists it may fail with an error about an email or a username. This change loosens the check on the plugin side to allow the plugin to continue if the bot already exists, regardless as to whether the server detects a username or email conflict first.

Resolves this issue, which was causing the plugin to fail to start:
```
{"timestamp":"2021-12-06 15:05:54.511 Z","level":"error","msg":"Unable to activate plugin","plugin_id":"com.mattermost.cloud","error":"failed to ensure Cloud bot: CreateBot: An account with that email already exists., invalid input: entity: User field: email value: cloud@localhost","stacktrace":[{"Function":"github.com/mattermost/mattermost-server/v6/app.(*Channels).syncPluginsActiveState.func2","File":"github.com/mattermost/mattermost-server/v6/app/plugin.go","Line":142},{"Function":"runtime.goexit","File":"runtime/asm_amd64.s","Line":1371}]}
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
None

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
