### PR TITLE
Add support for running mmctl commands

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -21,7 +21,7 @@ list
 	Lists the Mattermost installations created by you.
 
 import [DNS]
-	Imports installation using DNS value. 
+	Imports installation using DNS value.
 
 upgrade [name] [flags]
 	Upgades a Mattermost installaton.
@@ -34,6 +34,12 @@ mmcli [name] [mattermost-subcommand]
 
 	example: /cloud mmcli myinstallation version
 		(equivalent to running 'mattermost version' on myinstallation)
+
+mmctl [name] [mmctl-subcommand]
+	Runs mmctl commands on an installation.
+
+	example: /cloud mmctl myinstallation config get ServiceSettings.SiteURL
+		(equivalent to running 'mmctl config get ServiceSettings.SiteURL' on myinstallation)
 
 delete [name]
 	Deletes a Mattermost installation.
@@ -98,6 +104,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		handler = p.runCreateCommand
 	case "mmcli":
 		handler = p.runMattermostCLICommand
+	case "mmctl":
+		handler = p.runMmctlCommand
 	case "list":
 		handler = p.runListCommand
 	case "upgrade":

--- a/server/command_mmctl.go
+++ b/server/command_mmctl.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/pkg/errors"
+)
+
+func (p *Plugin) runMmctlCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	if len(args) == 0 {
+		return nil, true, errors.New("must provide an installation name")
+	}
+
+	name := standardizeName(args[0])
+	if name == "" {
+		return nil, true, errors.New("must provide an installation name")
+	}
+
+	subcommand := args[1:]
+	if len(subcommand) == 0 {
+		return nil, true, errors.New("must provide a mmctl command")
+	}
+
+	installsForUser, err := p.getInstallationsForUser(extra.UserId)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var installToExec *Installation
+	for _, install := range installsForUser {
+		if install.OwnerID == extra.UserId && install.Name == name {
+			installToExec = install
+			break
+		}
+	}
+
+	if installToExec == nil {
+		return nil, true, fmt.Errorf("no installation with the name %s found", name)
+	}
+
+	p.API.SendEphemeralPost(extra.UserId, &model.Post{
+		UserId:    p.BotUserID,
+		ChannelId: extra.ChannelId,
+		Message:   fmt.Sprintf("Running the command `mmctl %s` on `%s` now. Please wait as this may take a while.", strings.Join(subcommand, " "), installToExec.Name),
+	})
+
+	output, err := p.execMmctl(installToExec.ID, subcommand)
+	if err != nil {
+		return nil, false, err
+	}
+
+	resp := fmt.Sprintf("Installation: %s\n\nCommand: mmctl %s\n\nResponse:\n%s",
+		installToExec.Name,
+		strings.Join(subcommand, " "),
+		codeBlock(string(output)),
+	)
+
+	return getCommandResponse(model.CommandResponseTypeEphemeral, resp), false, nil
+}
+
+func (p *Plugin) execMmctl(installationID string, subcommand []string) ([]byte, error) {
+	clusterInstallations, err := p.cloudClient.GetClusterInstallations(&cloud.GetClusterInstallationsRequest{
+		InstallationID: installationID,
+		Paging:         cloud.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get cluster installations")
+	}
+
+	if len(clusterInstallations) == 0 {
+		return nil, fmt.Errorf("no cluster installations found for installation %s", installationID)
+	}
+
+	output, err := p.cloudClient.RunMmctlCommandOnClusterInstallation(clusterInstallations[0].ID, subcommand)
+	if err != nil && err.Error() == "failed with status code 504" {
+		// TODO: make this not gross.
+		// Return an error type that can be checked or allow us to pass in
+		// something with a timeout that we can control.
+		p.API.LogWarn(errors.Wrapf(err, "Command %s didn't complete before the connection was closed", strings.Join(subcommand, " ")).Error())
+		return []byte(fmt.Sprintf("Command %s didn't complete before the connection was closed. It will continue running until it is completed.", strings.Join(subcommand, " "))), nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/server/command_mmctl.go
+++ b/server/command_mmctl.go
@@ -74,13 +74,14 @@ func (p *Plugin) execMmctl(installationID string, subcommand []string) ([]byte, 
 		return nil, fmt.Errorf("no cluster installations found for installation %s", installationID)
 	}
 
-	output, err := p.cloudClient.RunMmctlCommandOnClusterInstallation(clusterInstallations[0].ID, subcommand)
+	subcommand = append(subcommand, "--local")
+	output, err := p.cloudClient.ExecClusterInstallationCLI(clusterInstallations[0].ID, "mmctl", subcommand)
 	if err != nil && err.Error() == "failed with status code 504" {
 		// TODO: make this not gross.
 		// Return an error type that can be checked or allow us to pass in
 		// something with a timeout that we can control.
-		p.API.LogWarn(errors.Wrapf(err, "Command %s didn't complete before the connection was closed", strings.Join(subcommand, " ")).Error())
-		return []byte(fmt.Sprintf("Command %s didn't complete before the connection was closed. It will continue running until it is completed.", strings.Join(subcommand, " "))), nil
+		p.API.LogWarn(errors.Wrapf(err, "Command /mmctl %s didn't complete before the connection was closed", strings.Join(subcommand, " ")).Error())
+		return []byte(fmt.Sprintf("Command /mmctl %s didn't complete before the connection was closed. It will continue running until it is completed.", strings.Join(subcommand, " "))), nil
 	} else if err != nil {
 		return nil, err
 	}

--- a/server/command_mmctl_test.go
+++ b/server/command_mmctl_test.go
@@ -33,7 +33,7 @@ func TestMmctlCommand(t *testing.T) {
 		resp, isUserError, err := plugin.runMmctlCommand([]string{"gabesinstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
 		require.NoError(t, err)
 		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, "mocked command output")
+		assert.Contains(t, resp.Text, "Installation: gabesinstall\n\nCommand: mmctl version\n\nResponse:\n```\n\n```")
 	})
 
 	t.Run("run command successfully with caps in name to show name is case insensitive", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestMmctlCommand(t *testing.T) {
 		resp, isUserError, err := plugin.runMmctlCommand([]string{"GabesInstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
 		require.NoError(t, err)
 		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, "mocked command output")
+		assert.Contains(t, resp.Text, "Installation: gabesinstall\n\nCommand: mmctl version\n\nResponse:\n```\n\n```")
 	})
 
 	t.Run("no name provided", func(t *testing.T) {

--- a/server/command_mmctl_test.go
+++ b/server/command_mmctl_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMmctlCommand(t *testing.T) {
+	mockedCloudClient := &MockClient{}
+	plugin := Plugin{cloudClient: mockedCloudClient}
+
+	api := &plugintest.API{}
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	api.On("SendEphemeralPost", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	plugin.SetAPI(api)
+
+	ci1 := &cloud.ClusterInstallation{
+		ID: cloud.NewID(),
+	}
+	mockedCloudClient.mockedCloudClusterInstallations = []*cloud.ClusterInstallation{ci1}
+
+	t.Run("run command successfully", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runMmctlCommand([]string{"gabesinstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "mocked command output")
+	})
+
+	t.Run("run command successfully with caps in name to show name is case insensitive", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runMmctlCommand([]string{"GabesInstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "mocked command output")
+	})
+
+	t.Run("no name provided", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMmctlCommand([]string{}, &model.CommandArgs{UserId: "gabeid2"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "must provide an installation name"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+
+		resp, isUserError, err = plugin.runMmctlCommand([]string{""}, &model.CommandArgs{UserId: "gabeid2"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "must provide an installation name"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no mmctl subcommand", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runMmctlCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must provide a mmctl command")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+
+		resp, isUserError, err := plugin.runMmctlCommand([]string{"gabesinstall2", "version"}, &model.CommandArgs{UserId: "gabeid2"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no installation with the name gabesinstall2 found")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no cluster installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+		mockedCloudClient.mockedCloudClusterInstallations = []*cloud.ClusterInstallation{}
+
+		resp, isUserError, err := plugin.runMmctlCommand([]string{"gabesinstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no cluster installations found for installation")
+		assert.False(t, isUserError)
+		assert.Nil(t, resp)
+	})
+}

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -76,6 +76,10 @@ func (mc *MockClient) RunMattermostCLICommandOnClusterInstallation(clusterInstal
 	return []byte("mocked command output"), nil
 }
 
+func (mc *MockClient) RunMmctlCommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error) {
+	return []byte("mocked mmctl command output"), nil
+}
+
 func (mc *MockClient) GetGroup(groupID string) (*cloud.Group, error) {
 	return &cloud.Group{ID: groupID, Name: "test-group"}, nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -44,6 +44,7 @@ type CloudClient interface {
 
 	GetClusterInstallations(request *cloud.GetClusterInstallationsRequest) ([]*cloud.ClusterInstallation, error)
 	RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error)
+	RunMmctlCommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error)
 	ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error)
 
 	GetGroup(groupID string) (*cloud.Group, error)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -44,7 +44,6 @@ type CloudClient interface {
 
 	GetClusterInstallations(request *cloud.GetClusterInstallationsRequest) ([]*cloud.ClusterInstallation, error)
 	RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error)
-	RunMmctlCommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error)
 	ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error)
 
 	GetGroup(groupID string) (*cloud.Group, error)


### PR DESCRIPTION
#### Summary

This PR adds support for running `mmctl` commands from the Cloud plugin slash commands.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-40727

#### Related Pull Requests

https://github.com/mattermost/mattermost-cloud/pull/586

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add support for running mmctl commands from the Cloud plugin
```
