### PR TITLE
Use default annotation for Installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 .DS_Store
+/.idea

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -17,6 +17,10 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+const (
+	defaultMultiTenantAnnotation = "multi-tenant"
+)
+
 var dockerRepoWhitelist = []string{
 	"mattermost/mattermost-enterprise-edition",
 	"mattermost/mm-ee-test",
@@ -211,16 +215,17 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 	install.Version = digest
 
 	req := &cloud.CreateInstallationRequest{
-		OwnerID:   extra.UserId,
-		GroupID:   config.GroupID,
-		Affinity:  install.Affinity,
-		DNS:       fmt.Sprintf("%s.%s", install.Name, config.InstallationDNS),
-		Database:  install.Database,
-		Filestore: install.Filestore,
-		License:   license,
-		Size:      install.Size,
-		Version:   install.Version,
-		Image:     install.Image,
+		OwnerID:     extra.UserId,
+		GroupID:     config.GroupID,
+		Affinity:    install.Affinity,
+		DNS:         fmt.Sprintf("%s.%s", install.Name, config.InstallationDNS),
+		Database:    install.Database,
+		Filestore:   install.Filestore,
+		License:     license,
+		Size:        install.Size,
+		Version:     install.Version,
+		Image:       install.Image,
+		Annotations: []string{defaultMultiTenantAnnotation},
 	}
 
 	cloudInstallation, err := p.cloudClient.CreateInstallation(req)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Use `multi-tenant` annotation for Cloud Plugin Installation so that they are not scheduled on e2e tests clusters.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Use default annotation for Installations
```
