### PR TITLE
[MM-27500] Creation now exposes one regular and one admin user

### DIFF
--- a/server/installation.go
+++ b/server/installation.go
@@ -197,6 +197,14 @@ func (p *Plugin) getInstallation(installationID string) (*Installation, error) {
 
 	for _, install := range installs {
 		if install.ID == installationID {
+			// Retrieve the information we need from the installation directly from the provisioner
+			cloudInstall, err := p.cloudClient.GetInstallation(install.ID, &cloud.GetInstallationRequest{})
+			if err != nil {
+				return nil, err
+			}
+
+			install.DNSRecords = cloudInstall.DNSRecords
+
 			return install, nil
 		}
 	}

--- a/server/installation.go
+++ b/server/installation.go
@@ -198,12 +198,14 @@ func (p *Plugin) getInstallation(installationID string) (*Installation, error) {
 	for _, install := range installs {
 		if install.ID == installationID {
 			// Retrieve the information we need from the installation directly from the provisioner
-			cloudInstall, err := p.cloudClient.GetInstallation(install.ID, &cloud.GetInstallationRequest{})
-			if err != nil {
-				return nil, err
-			}
+			if len(install.DNSRecords) == 0 {
+				cloudInstall, err := p.cloudClient.GetInstallation(install.ID, &cloud.GetInstallationRequest{})
+				if err != nil {
+					return nil, err
+				}
 
-			install.DNSRecords = cloudInstall.DNSRecords
+				install.DNSRecords = cloudInstall.DNSRecords
+			}
 
 			return install, nil
 		}

--- a/server/setup.go
+++ b/server/setup.go
@@ -18,7 +18,7 @@ const (
 	defaultAdminEmail    = "success+sysadmin@simulator.amazonses.com"
 
 	defaultUserUsername = "user"
-	defaultUserPassword = defaultAdminPassword
+	defaultUserPassword = "User@123"
 	defaultUserEmail    = "success+user@simulator.amazonses.com"
 )
 

--- a/server/setup.go
+++ b/server/setup.go
@@ -16,6 +16,10 @@ const (
 	defaultAdminUsername = "sysadmin"
 	defaultAdminPassword = "Sys@dmin123"
 	defaultAdminEmail    = "success+sysadmin@simulator.amazonses.com"
+
+	defaultUserUsername = "user"
+	defaultUserPassword = defaultAdminPassword
+	defaultUserEmail    = "success+user@simulator.amazonses.com"
 )
 
 func (p *Plugin) setupInstallation(install *Installation) error {
@@ -43,6 +47,12 @@ func (p *Plugin) setupInstallation(install *Installation) error {
 		return errors.Wrap(err, "encountered an error configuring the installation")
 	}
 
+	// Create normal user
+	err = p.createUser(client, defaultUserUsername, defaultUserPassword, defaultUserEmail)
+	if err != nil {
+		return errors.Wrap(err, "encountered an error creating installation user account")
+	}
+
 	return nil
 }
 
@@ -61,14 +71,19 @@ func (p *Plugin) waitForDNS(client *model.Client4) error {
 	return errors.New("timed out waiting for installation DNS")
 }
 
-func (p *Plugin) createAndLoginAdminUser(client *model.Client4) error {
+func (p *Plugin) createUser(client *model.Client4, username, password, email string) error {
 	_, _, err := client.CreateUser(
 		&model.User{
-			Username: defaultAdminUsername,
-			Password: defaultAdminPassword,
-			Email:    defaultAdminEmail,
+			Username: username,
+			Password: password,
+			Email:    email,
 		},
 	)
+	return err
+}
+
+func (p *Plugin) createAndLoginAdminUser(client *model.Client4) error {
+	err := p.createUser(client, defaultAdminUsername, defaultAdminPassword, defaultAdminEmail)
 	if err != nil {
 		return err
 	}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -128,13 +128,14 @@ Access at: https://%s
 
 Login with:
 
-| Username | Password |
-| -- | -- |
-| %s | %s |
+| Username | Password | Note |
+| -- | -- | -- |
+| %s | %s | Admin user |
+| %s | %s | Regular user |
 
 Installation details:
 %s
-`, install.Name, dnsRecord, defaultAdminUsername, defaultAdminPassword, jsonCodeBlock(install.ToPrettyJSON()))
+`, install.Name, dnsRecord, defaultAdminUsername, defaultAdminPassword, defaultUserUsername, defaultUserPassword, jsonCodeBlock(install.ToPrettyJSON()))
 
 		p.PostBotDM(install.OwnerID, message)
 	}


### PR DESCRIPTION
#### Summary

- Provision an additional regular user on installation creation
- Fixes `Installation` not having `DNSRecords` nor `DNS` for Installation connection

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-27500

#### Release Note

```release-note
Provision an additional regular user on installation creation
```
