### PR TITLE
[MM-49990] Remove database options from the cloud plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 .DS_Store
 /.idea
+vendor/

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -42,7 +42,7 @@ func getCreateFlagSet() *flag.FlagSet {
 	createFlagSet.String("affinity", cloud.InstallationAffinityMultiTenant, "Whether the installation is isolated in it's own cluster or shares ones. Can be 'isolated' or 'multitenant'")
 	createFlagSet.String("license", licenseOptionE20, "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
 	createFlagSet.String("filestore", cloud.InstallationFilestoreBifrost, "Specify the backing file store. Can be 'aws-multitenant-s3' (S3 Shared Bucket), 'aws-s3' (S3 Bucket), 'operator' (Minio Operator inside the cluster. Default 'aws-multi-tenant-s3' for E20, and 'aws-s3' for E10 and E0/TE.")
-	createFlagSet.String("database", cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer, "Specify the backing database. Can be 'perseus' (RDS Postgres with perseus proxy connections), 'aws-multitenant-rds-postgres-pgbouncer' (RDS Postgres with pgbouncer proxy connections), 'aws-multitenant-rds-postgres' (RDS Postgres Shared), 'aws-multitenant-rds' (RDS MySQL Shared), 'aws-rds-postgres' (RDS Postgres), 'aws-rds' (RDS MySQL), 'mysql-operator' (MySQL Operator inside the cluster)")
+	createFlagSet.String("database", cloud.InstallationDatabasePerseus, "Specify the backing database. Can be 'perseus' (RDS Postgres with perseus proxy connections), 'aws-multitenant-rds-postgres-pgbouncer' (RDS Postgres with pgbouncer proxy connections), 'mysql-operator' (MySQL Operator inside the cluster)")
 	createFlagSet.Bool("test-data", false, "Set to pre-load the server with test data")
 	createFlagSet.String("image", defaultImage, fmt.Sprintf("Docker image repository. Can be %s", strings.Join(dockerRepoWhitelist, ", ")))
 	createFlagSet.StringSlice("env", []string{}, "Environment variables in form: ENV1=test,ENV2=test")
@@ -110,16 +110,12 @@ func (p *Plugin) parseCreateArgs(args []string, install *Installation) error {
 		return err
 	}
 
-	if !cloud.IsSupportedDatabase(install.Database) {
-		return errors.Errorf("invalid database option %s; valid options are: %s, %s, %s, %s, %s, %s, %s",
+	if !isSupportedDatabase(install.Database) {
+		return errors.Errorf("invalid database option %s; valid options are: %s, %s, %s",
 			install.Database,
 			cloud.InstallationDatabasePerseus,
 			cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
 			cloud.InstallationDatabaseMysqlOperator,
-			cloud.InstallationDatabaseSingleTenantRDSMySQL,
-			cloud.InstallationDatabaseSingleTenantRDSPostgres,
-			cloud.InstallationDatabaseMultiTenantRDSMySQL,
-			cloud.InstallationDatabaseMultiTenantRDSPostgres,
 		)
 	}
 

--- a/server/command_create_test.go
+++ b/server/command_create_test.go
@@ -137,34 +137,6 @@ func TestCreateCommand(t *testing.T) {
 			assert.Contains(t, resp.Text, "Installation being created.")
 		})
 
-		t.Run(cloud.InstallationDatabaseSingleTenantRDSMySQL, func(t *testing.T) {
-			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseSingleTenantRDSMySQL}, &model.CommandArgs{})
-			require.NoError(t, err)
-			assert.False(t, isUserError)
-			assert.Contains(t, resp.Text, "Installation being created.")
-		})
-
-		t.Run(cloud.InstallationDatabaseMultiTenantRDSMySQL, func(t *testing.T) {
-			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseMultiTenantRDSMySQL}, &model.CommandArgs{})
-			require.NoError(t, err)
-			assert.False(t, isUserError)
-			assert.Contains(t, resp.Text, "Installation being created.")
-		})
-
-		t.Run(cloud.InstallationDatabaseSingleTenantRDSPostgres, func(t *testing.T) {
-			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseSingleTenantRDSPostgres}, &model.CommandArgs{})
-			require.NoError(t, err)
-			assert.False(t, isUserError)
-			assert.Contains(t, resp.Text, "Installation being created.")
-		})
-
-		t.Run(cloud.InstallationDatabaseMultiTenantRDSPostgres, func(t *testing.T) {
-			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseMultiTenantRDSPostgres}, &model.CommandArgs{})
-			require.NoError(t, err)
-			assert.False(t, isUserError)
-			assert.Contains(t, resp.Text, "Installation being created.")
-		})
-
 		t.Run(cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer, func(t *testing.T) {
 			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer}, &model.CommandArgs{})
 			require.NoError(t, err)

--- a/server/command_create_test.go
+++ b/server/command_create_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -122,19 +123,50 @@ func TestCreateCommand(t *testing.T) {
 	})
 
 	t.Run("database", func(t *testing.T) {
-		t.Run("invalid", func(t *testing.T) {
+		t.Run("sqlite", func(t *testing.T) {
 			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", "sqlite"}, &model.CommandArgs{})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid database option sqlite")
 			assert.True(t, isUserError)
 			assert.Nil(t, resp)
 		})
-
 		t.Run(cloud.InstallationDatabaseMysqlOperator, func(t *testing.T) {
 			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseMysqlOperator}, &model.CommandArgs{})
 			require.NoError(t, err)
 			assert.False(t, isUserError)
 			assert.Contains(t, resp.Text, "Installation being created.")
+		})
+
+		t.Run(cloud.InstallationDatabaseSingleTenantRDSMySQL, func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseSingleTenantRDSMySQL}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprintf("invalid database option %s", cloud.InstallationDatabaseSingleTenantRDSMySQL))
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+
+		t.Run(cloud.InstallationDatabaseMultiTenantRDSMySQL, func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseMultiTenantRDSMySQL}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprintf("invalid database option %s", cloud.InstallationDatabaseMultiTenantRDSMySQL))
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+
+		t.Run(cloud.InstallationDatabaseSingleTenantRDSPostgres, func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseSingleTenantRDSPostgres}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprintf("invalid database option %s", cloud.InstallationDatabaseSingleTenantRDSPostgres))
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+
+		t.Run(cloud.InstallationDatabaseMultiTenantRDSPostgres, func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--database", cloud.InstallationDatabaseMultiTenantRDSPostgres}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprintf("invalid database option %s", cloud.InstallationDatabaseMultiTenantRDSPostgres))
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
 		})
 
 		t.Run(cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer, func(t *testing.T) {

--- a/server/utils.go
+++ b/server/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
+	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 )
 
@@ -75,3 +76,16 @@ func NewInt64(n int64) *int64 { return &n }
 
 // NewString returns a pointer to a given string.
 func NewString(s string) *string { return &s }
+
+// isSupportedDatabase returns true if the given database string is supported.
+func isSupportedDatabase(database string) bool {
+	switch database {
+	case cloud.InstallationDatabasePerseus:
+	case cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer:
+	case cloud.InstallationDatabaseMysqlOperator:
+	default:
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

We are only supporting following databases in cloud plugin.
- perseus (default)
- pgbouncer
- mysql-operator

#### Ticket Link

  Ticket [MM-49990](https://mattermost.atlassian.net/browse/MM-49990)


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Only supports perseus, pgbouncer, & mysql-operator
```
