### PR TITLE
Add new license type options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/heroku/docker-registry-client v0.0.0-20211012143308-9463674c8930
-	github.com/mattermost/mattermost-cloud v0.69.1-0.20230110172417-1b7b8978b25f
+	github.com/mattermost/mattermost-cloud v0.70.1
 	github.com/mattermost/mattermost-server/v6 v6.7.2
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 )
 
 require (
@@ -28,7 +28,7 @@ require (
 	github.com/emicklei/go-restful v2.11.2+incompatible // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
@@ -57,7 +57,7 @@ require (
 	github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 // indirect
 	github.com/mattermost/ldap v3.0.4+incompatible // indirect
 	github.com/mattermost/logr/v2 v2.0.15 // indirect
-	github.com/mattermost/mattermost-operator v1.19.0-rc.2 // indirect
+	github.com/mattermost/mattermost-operator v1.20.0-rc.2 // indirect
 	github.com/mattermost/rotator v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KE
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
-github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
@@ -1011,10 +1011,10 @@ github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
 github.com/mattermost/logr/v2 v2.0.15 h1:+WNbGcsc3dBao65eXlceB6dTILNJRIrvubnsTl3zBew=
 github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
-github.com/mattermost/mattermost-cloud v0.69.1-0.20230110172417-1b7b8978b25f h1:xb9dyvoWBJNCso60t8+f4DH7DLHPrqPR3dHvlwJNscA=
-github.com/mattermost/mattermost-cloud v0.69.1-0.20230110172417-1b7b8978b25f/go.mod h1:TLVxK7W/UkX3LvJf/lEEvjxSCfXEBvcbVjLxskYeOHQ=
-github.com/mattermost/mattermost-operator v1.19.0-rc.2 h1:CcCAB02qz4u47yHXIJm3glLDfKo63RFjtGNaJ+31BEA=
-github.com/mattermost/mattermost-operator v1.19.0-rc.2/go.mod h1:427nFmeCyiwJ9N0J7hpYJNYE6a3DjPdwl0Vpel3JHVg=
+github.com/mattermost/mattermost-cloud v0.70.1 h1:fQZZmDVtrbXKKBeoQIt/Bqu+tOhNRwBzYT10n5vTXrY=
+github.com/mattermost/mattermost-cloud v0.70.1/go.mod h1:dFQLFXVqwZACqfZ+j40tn6wzIjjcO6XuCESGQcBUS+M=
+github.com/mattermost/mattermost-operator v1.20.0-rc.2 h1:crGusVBsw0zOavJWVaaYExr+ippAq+C3qZzf5VMz9nM=
+github.com/mattermost/mattermost-operator v1.20.0-rc.2/go.mod h1:WGxmW6iF1+cFc3sJ5uZTVAHolIMjt2/zHumeI7Xt7Hk=
 github.com/mattermost/mattermost-server/v6 v6.7.2 h1:rRss2/R5LNbyc/P1OA4kSWuVq+rmnxwepuwGpTwL+U4=
 github.com/mattermost/mattermost-server/v6 v6.7.2/go.mod h1:b/iDf7Jn2Pd2jWGzaznoVNT811JZpemdmNGP7M/a7Ao=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
@@ -1434,8 +1434,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/plugin.json
+++ b/plugin.json
@@ -56,6 +56,18 @@
                 "help_text": "The contents of a E20 license."
             },
             {
+                "key": "EnterpriseLicense",
+                "display_name": "Mattermost Enterprise License",
+                "type": "longtext",
+                "help_text": "The contents of an Enterpise license."
+            },
+            {
+                "key": "ProfessionalLicense",
+                "display_name": "Mattermost Professional License",
+                "type": "longtext",
+                "help_text": "The contents of a Professional license."
+            },
+            {
                 "key": "GroupID",
                 "display_name": "Group ID",
                 "type": "text",

--- a/server/command.go
+++ b/server/command.go
@@ -27,7 +27,7 @@ upgrade [name] [flags]
 	Upgrades a Mattermost installation.
 	Flags:
 %s
-	example: /cloud upgrade myinstallation --version 5.13.2
+	example: /cloud upgrade myinstallation --version 7.8.1
 
 hibernate [name]
 	Hibernates a Mattermost installation.

--- a/server/command_create_test.go
+++ b/server/command_create_test.go
@@ -90,12 +90,42 @@ func TestCreateCommand(t *testing.T) {
 		})
 	})
 
-	t.Run("invalid license", func(t *testing.T) {
-		resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--license", "e30"}, &model.CommandArgs{})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid license option")
-		assert.True(t, isUserError)
-		assert.Nil(t, resp)
+	t.Run("licenses", func(t *testing.T) {
+		t.Run("invalid", func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--license", "e30"}, &model.CommandArgs{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid license option")
+			assert.True(t, isUserError)
+			assert.Nil(t, resp)
+		})
+
+		t.Run("enterprise", func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--license", "enterprise"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation being created")
+		})
+
+		t.Run("professional", func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--license", "professional"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation being created")
+		})
+
+		t.Run("e20", func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--license", "e20"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation being created")
+		})
+
+		t.Run("e10", func(t *testing.T) {
+			resp, isUserError, err := plugin.runCreateCommand([]string{"joramtest", "--license", "e10"}, &model.CommandArgs{})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Installation being created")
+		})
 	})
 
 	t.Run("affinity", func(t *testing.T) {
@@ -211,7 +241,7 @@ func TestCreateCommand(t *testing.T) {
 		t.Run("invalid license option", func(t *testing.T) {
 			resp, isUserError, err := plugin.runCreateCommand([]string{"gabetest", "--filestore", cloud.InstallationFilestoreMultiTenantAwsS3, "--license", licenseOptionTE}, &model.CommandArgs{})
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "filestore option aws-multitenant-s3 requires license option e20")
+			assert.Contains(t, err.Error(), "filestore option aws-multitenant-s3 requires license option enterprise or e20")
 			assert.True(t, isUserError)
 			assert.Nil(t, resp)
 		})

--- a/server/command_upgrade_test.go
+++ b/server/command_upgrade_test.go
@@ -101,6 +101,24 @@ func TestUpgradeCommand(t *testing.T) {
 			assert.Nil(t, resp)
 		})
 
+		t.Run("enterprise", func(t *testing.T) {
+			api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+			resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall", "--license", licenseOptionE20}, &model.CommandArgs{UserId: "gabeid"})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Upgrade of installation")
+		})
+
+		t.Run("professional", func(t *testing.T) {
+			api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+			resp, isUserError, err := plugin.runUpgradeCommand([]string{"gabesinstall", "--license", licenseOptionProfessional}, &model.CommandArgs{UserId: "gabeid"})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Upgrade of installation")
+		})
+
 		t.Run("e20", func(t *testing.T) {
 			api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -9,11 +9,22 @@ import (
 )
 
 const (
-	licenseOptionE10 = "e10"
-	licenseOptionE20 = "e20"
-	licenseOptionTE  = "te"
-	defaultImage     = "mattermost/mattermost-enterprise-edition"
+	licenseOptionEnterprise   = "enterprise"
+	licenseOptionProfessional = "professional"
+	licenseOptionE20          = "e20"
+	licenseOptionE10          = "e10"
+	licenseOptionTE           = "te"
+
+	defaultImage = "mattermost/mattermost-enterprise-edition"
 )
+
+var validLicenseOptions = []string{
+	licenseOptionEnterprise,
+	licenseOptionProfessional,
+	licenseOptionE20,
+	licenseOptionE10,
+	licenseOptionTE,
+}
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server
 // configuration, as well as values computed from the configuration. Any public fields will be
@@ -33,8 +44,10 @@ type configuration struct {
 	AllowedEmailDomain          string
 
 	// License
-	E10License string
-	E20License string
+	E10License          string
+	E20License          string
+	EnterpriseLicense   string
+	ProfessionalLicense string
 
 	// Groups
 	GroupID string
@@ -159,4 +172,21 @@ func (p *Plugin) setCloudClient() {
 
 	authHeaders := map[string]string{"x-api-key": configuration.ProvisioningServerAuthToken}
 	p.cloudClient = cloud.NewClientWithHeaders(configuration.ProvisioningServerURL, authHeaders)
+}
+
+func (p *Plugin) getLicenseValue(option string) string {
+	config := p.getConfiguration()
+
+	switch option {
+	case licenseOptionEnterprise:
+		return config.EnterpriseLicense
+	case licenseOptionProfessional:
+		return config.ProfessionalLicense
+	case licenseOptionE20:
+		return config.E20License
+	case licenseOptionE10:
+		return config.E10License
+	}
+
+	return ""
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -37,7 +37,11 @@ func standardizeName(name string) string {
 }
 
 func validLicenseOption(license string) bool {
-	return license == licenseOptionE10 || license == licenseOptionE20 || license == licenseOptionTE
+	return license == licenseOptionEnterprise ||
+		license == licenseOptionProfessional ||
+		license == licenseOptionE20 ||
+		license == licenseOptionE10 ||
+		license == licenseOptionTE
 }
 
 func validVersionOption(version string) error {


### PR DESCRIPTION
The new options are 'enterprise' and 'professional'. Old license options remain for testing.

```release-note
Add new license type options
```
