### PR TITLE
feat: provide grafana links for created installs

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -1,14 +1,38 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
 )
+
+const (
+	installationLogsURLTmpl = "https://grafana.internal.mattermost.com/explore?orgId=1&left=%7B%22datasource%22:%22PFB2D5CACEC34D62E%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22PFB2D5CACEC34D62E%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bapp%3D%5C%22mattermost%5C%22,%20namespace%3D%5C%22{{.ID}}%5C%22%7D%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"
+	provisionerLogsURLTmpl  = "https://grafana.internal.mattermost.com/explore?orgId=1&left=%7B%22datasource%22:%22PFB2D5CACEC34D62E%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22PFB2D5CACEC34D62E%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bnamespace%3D%5C%22mattermost-cloud-test%5C%22,%20component%3D%5C%22provisioner%5C%22%7D%20%7C%3D%20%60{{.ID}}%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D"
+)
+
+// getStringFromTemplate returns a string from a template and data provided.
+func getStringFromTemplate(tmpl string, data any) (string, error) {
+	t, err := template.New("tmpl").Parse(tmpl)
+	if err != nil {
+		return "", errors.Wrap(err, "error parsing template")
+	}
+
+	var result bytes.Buffer
+	err = t.Execute(&result, data)
+	if err != nil {
+		return "", errors.Wrap(err, "error executing template")
+	}
+
+	return result.String(), nil
+}
 
 func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	payload, err := cloud.WebhookPayloadFromReader(r.Body)
@@ -121,6 +145,18 @@ Installation details:
 
 		install.HideSensitiveFields()
 
+		installationLogsURL, err := getStringFromTemplate(installationLogsURLTmpl, install)
+		if err != nil {
+			p.API.LogError(err.Error(), "installation", install.Name)
+			return
+		}
+
+		provisionerLogsURL, err := getStringFromTemplate(provisionerLogsURLTmpl, install)
+		if err != nil {
+			p.API.LogError(err.Error(), "installation", install.Name)
+			return
+		}
+
 		message := fmt.Sprintf(`
 Installation %s is ready!
 
@@ -133,9 +169,14 @@ Login with:
 | %s | %s | Admin user |
 | %s | %s | Regular user |
 
+Grafana logs for this installation:
+
+- [Installation logs](%s)
+- [Provisioner logs](%s)
+
 Installation details:
 %s
-`, install.Name, dnsRecord, defaultAdminUsername, defaultAdminPassword, defaultUserUsername, defaultUserPassword, jsonCodeBlock(install.ToPrettyJSON()))
+`, install.Name, dnsRecord, defaultAdminUsername, defaultAdminPassword, defaultUserUsername, defaultUserPassword, installationLogsURL, provisionerLogsURL, jsonCodeBlock(install.ToPrettyJSON()))
 
 		p.PostBotDM(install.OwnerID, message)
 	}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	installationLogsURLTmpl = "https://grafana.internal.mattermost.com/explore?orgId=1&left=%7B%22datasource%22:%22PFB2D5CACEC34D62E%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22PFB2D5CACEC34D62E%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bapp%3D%5C%22mattermost%5C%22,%20namespace%3D%5C%22{{.ID}}%5C%22%7D%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"
-	provisionerLogsURLTmpl  = "https://grafana.internal.mattermost.com/explore?orgId=1&left=%7B%22datasource%22:%22PFB2D5CACEC34D62E%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22PFB2D5CACEC34D62E%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bnamespace%3D%5C%22mattermost-cloud-test%5C%22,%20component%3D%5C%22provisioner%5C%22%7D%20%7C%3D%20%60{{.ID}}%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D"
+	installationLogsURLTmpl = `https://grafana.internal.mattermost.com/explore?orgId=1&left={"datasource":"PFB2D5CACEC34D62E","queries":[{"refId":"A","datasource":{"type":"loki","uid":"PFB2D5CACEC34D62E"},"editorMode":"code","expr":"{app=\"mattermost\", namespace=\"{{.ID}}\"}","queryType":"range"}],"range":{"from":"now-1h","to":"now"}}`
+	provisionerLogsURLTmpl  = `https://grafana.internal.mattermost.com/explore?orgId=1&left={"datasource":"PFB2D5CACEC34D62E","queries":[{"refId":"A","datasource":{"type":"loki","uid":"PFB2D5CACEC34D62E"},"editorMode":"code","expr":"{namespace=\"mattermost-cloud-test\", component=\"provisioner\"} |= %60{{.ID}}%60","queryType":"range"}],"range":{"from":"now-3h","to":"now"}}`
 )
 
 // getStringFromTemplate returns a string from a template and data provided.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Adds two links to the installation creation details to the grafana logs of both the installation and the provisioner filtered by the installation ID.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-51419

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
feat: provide grafana links for created installs
```
