### PR TITLE
[MM-51743] Add plugin options for default database and filestore

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -104,6 +104,52 @@
                 "display_name": "Installation Webhook Alerts Channel ID",
                 "type": "text",
                 "help_text": "The channel ID to send installation webhook alerts to when enabled. This channel must exist for alerts to be sent."
+            },
+            {
+                "key": "DefaultDatabase",
+                "display_name": "Default Database",
+                "type": "dropdown",
+                "help_text": "The default database to use for new installations.",
+                "default": "aws-multitenant-rds-postgres-pgbouncer",
+                "options": [
+                    {
+                        "display_name": "Perseus",
+                        "value": "perseus"
+                    },
+                    {
+                        "display_name": "PgBouncer",
+                        "value": "aws-multitenant-rds-postgres-pgbouncer"
+                    },
+                    {
+                        "display_name": "MySQL Operator",
+                        "value": "mysql-operator"
+                    }
+                ]
+            },
+            {
+                "key": "DefaultFilestore",
+                "display_name": "Default Filestore",
+                "type": "dropdown",
+                "help_text": "The default filestore to use for new installations.",
+                "default": "bifrost",
+                "options": [
+                    {
+                        "display_name": "Bifrost",
+                        "value": "bifrost"
+                    },
+                    {
+                        "display_name": "AWS Multitenant S3",
+                        "value": "aws-multitenant-s3"
+                    },
+                    {
+                        "display_name": "AWS S3",
+                        "value": "aws-s3"
+                    },
+                    {
+                        "display_name": "Minio Operator",
+                        "value": "minio-operator"
+                    }
+                ]
             }
         ]
     }

--- a/server/command.go
+++ b/server/command.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
-func getHelp() string {
+func (p *Plugin) getHelp() string {
 	help := `Available Commands:
 
 create [name] [flags]
@@ -55,7 +55,7 @@ info
 `
 	return codeBlock(fmt.Sprintf(
 		help,
-		getCreateFlagSet().FlagUsages(),
+		p.getCreateFlagSet().FlagUsages(),
 		getUpgradeFlagSet().FlagUsages(),
 	))
 }
@@ -98,7 +98,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	stringArgs := strings.Split(args.Command, " ")
 
 	if len(stringArgs) < 2 {
-		return getCommandResponse(model.CommandResponseTypeEphemeral, getHelp(), args), nil
+		return getCommandResponse(model.CommandResponseTypeEphemeral, p.getHelp(), args), nil
 	}
 
 	command := stringArgs[1]
@@ -131,7 +131,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	}
 
 	if handler == nil {
-		return getCommandResponse(model.CommandResponseTypeEphemeral, getHelp(), args), nil
+		return getCommandResponse(model.CommandResponseTypeEphemeral, p.getHelp(), args), nil
 	}
 
 	resp, isUserError, err := handler(stringArgs[2:], args)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -62,6 +62,9 @@ type configuration struct {
 
 	InstallationWebhookAlertsEnable    bool
 	InstallationWebhookAlertsChannelID string
+
+	DefaultDatabase  string
+	DefaultFilestore string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if


### PR DESCRIPTION
#### Summary

We can now set default database and filestore option from plugin's setting.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-51743


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Set default database and filestore option from plugin's setting.
```
