### PR TITLE
Remove the metadata from tar by setting COPYFILE_DISABLE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_ID)/webapp/dist;
 	cp -r webapp/dist/* dist/$(PLUGIN_ID)/webapp/dist/;
 endif
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd dist && COPYFILE_DISABLE=1 tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 


### PR DESCRIPTION
#### Summary

When we make the tar file with`tar -cvzf`, OSX adds a `._` file for each file.

```
._com.mattermost.cloud
com.mattermost.cloud/
com.mattermost.cloud/._webapp
com.mattermost.cloud/webapp/
com.mattermost.cloud/._server
com.mattermost.cloud/server/
```

And this causes problem in mm-server. [Issue filed](https://github.com/mattermost/mattermost-server/issues/22614)

To solve this, we need to tell tar to remove the metadata by setting `COPYFILE_DISABLE`. [Reference](https://apple.stackexchange.com/questions/75989/why-does-osx-add-extra-filename-when-i-tar-a-directory).

So run `COPYFILE_DISABLE=1 tar -cvzf` to make tar file.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
