### PR TITLE
Use test licenses for certain docker repos

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -68,6 +68,18 @@
                 "help_text": "The contents of a Professional license."
             },
             {
+                "key": "TestEnterpriseLicense",
+                "display_name": "Mattermost Enterprise License used for servers built for internal testing",
+                "type": "longtext",
+                "help_text": "The contents of an Enterpise license."
+            },
+            {
+                "key": "TestProfessionalLicense",
+                "display_name": "Mattermost Professional License used for servers built for internal testing",
+                "type": "longtext",
+                "help_text": "The contents of a Professional license."
+            },
+            {
                 "key": "GroupID",
                 "display_name": "Group ID",
                 "type": "text",

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -21,14 +21,6 @@ const (
 	defaultMultiTenantAnnotation = "multi-tenant"
 )
 
-var dockerRepoWhitelist = []string{
-	"mattermost/mattermost-enterprise-edition",
-	"mattermost/mm-ee-cloud",
-	"mattermost/mm-te",
-	"mattermost/mattermost-team-edition",
-	"mattermostdevelopment/mm-ee-test",
-	"mattermostdevelopment/mm-te-test",
-}
 var installationNameMatcher = regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
 
 var validInstallationSizes = []string{"miniSingleton", "miniHA"}
@@ -236,7 +228,7 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		Database:    install.Database,
 		Filestore:   install.Filestore,
 		PriorityEnv: install.PriorityEnv,
-		License:     p.getLicenseValue(install.License),
+		License:     p.getLicenseValue(install.License, install.Image),
 		Size:        install.Size,
 		Version:     install.Version,
 		Image:       install.Image,

--- a/server/command_upgrade.go
+++ b/server/command_upgrade.go
@@ -13,7 +13,7 @@ import (
 func getUpgradeFlagSet() *flag.FlagSet {
 	upgradeFlagSet := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	upgradeFlagSet.String("version", "", "Mattermost version to run, e.g. '5.12.4'")
-	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'e10', 'e20', or 'te'")
+	upgradeFlagSet.String("license", "", "The enterprise license to use. Can be 'enterprise', 'professional', 'e20', 'e10', or 'te'")
 	upgradeFlagSet.String("size", "", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
 	upgradeFlagSet.String("image", "", fmt.Sprintf("Docker image repository, can be %s", strings.Join(dockerRepoWhitelist, ", ")))
 	upgradeFlagSet.StringSlice("env", []string{}, "Environment variables in form: ENV1=test,ENV2=test")
@@ -151,9 +151,14 @@ func (p *Plugin) runUpgradeCommand(args []string, extra *model.CommandArgs) (*mo
 		request.Version = &digest
 	}
 
+	// Obtain the new image value if there is one to properly apply a license.
+	image := installToUpgrade.Image
+	if request.Image != nil {
+		image = *request.Image
+	}
 	if request.License != nil {
 		// Translate the license option.
-		licenseValue := p.getLicenseValue(*request.License)
+		licenseValue := p.getLicenseValue(*request.License, image)
 		request.License = &licenseValue
 	}
 

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,6 +68,55 @@ func TestConfigurationIsValid(t *testing.T) {
 		t.Run("valid", func(t *testing.T) {
 			config.InstallationWebhookAlertsChannelID = "channel1"
 			require.NoError(t, config.IsValid())
+		})
+	})
+}
+
+func TestGetLicenseValue(t *testing.T) {
+	plugin := Plugin{
+		configuration: &configuration{
+			E10License:              "e10license",
+			E20License:              "e20license",
+			EnterpriseLicense:       "enterpriselicense",
+			ProfessionalLicense:     "professionallicense",
+			TestEnterpriseLicense:   "testenterpriselicense",
+			TestProfessionalLicense: "testprofessionallicense",
+		},
+	}
+
+	t.Run("e20", func(t *testing.T) {
+		t.Run("no test image", func(t *testing.T) {
+			assert.Equal(t, "e20license", plugin.getLicenseValue(licenseOptionE20, imageEE))
+		})
+		t.Run("test image", func(t *testing.T) {
+			assert.Equal(t, "e20license", plugin.getLicenseValue(licenseOptionE20, imageEETest))
+		})
+	})
+
+	t.Run("e10", func(t *testing.T) {
+		t.Run("no test image", func(t *testing.T) {
+			assert.Equal(t, "e10license", plugin.getLicenseValue(licenseOptionE10, imageEE))
+		})
+		t.Run("test image", func(t *testing.T) {
+			assert.Equal(t, "e10license", plugin.getLicenseValue(licenseOptionE10, imageEETest))
+		})
+	})
+
+	t.Run("enterprise", func(t *testing.T) {
+		t.Run("no test image", func(t *testing.T) {
+			assert.Equal(t, "enterpriselicense", plugin.getLicenseValue(licenseOptionEnterprise, imageEE))
+		})
+		t.Run("test image", func(t *testing.T) {
+			assert.Equal(t, "testenterpriselicense", plugin.getLicenseValue(licenseOptionEnterprise, imageEETest))
+		})
+	})
+
+	t.Run("professional", func(t *testing.T) {
+		t.Run("no test image", func(t *testing.T) {
+			assert.Equal(t, "professionallicense", plugin.getLicenseValue(licenseOptionProfessional, imageEE))
+		})
+		t.Run("test image", func(t *testing.T) {
+			assert.Equal(t, "testprofessionallicense", plugin.getLicenseValue(licenseOptionProfessional, imageEETest))
 		})
 	})
 }


### PR DESCRIPTION
Certain docker repositories contain artifacts built for internal testing. When one of these is selected along with enterprise or professional license types, we now apply a different license payload which is defined in the plugin configuration.

Fixes https://mattermost.atlassian.net/browse/MM-52427

```release-note
Use test licenses for certain docker repos
```
