### PR TITLE
[CLD-6025] Add a LHS button for opening the cloud plugin

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -132,7 +132,6 @@ export function setShowRHSAction(showRHSPluginAction) {
 }
 
 export function setRhsVisible(payload) {
-    console.log("helloooo");
     return {
         type: SET_RHS_VISIBLE,
         payload,

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -132,6 +132,7 @@ export function setShowRHSAction(showRHSPluginAction) {
 }
 
 export function setRhsVisible(payload) {
+    console.log("helloooo");
     return {
         type: SET_RHS_VISIBLE,
         payload,

--- a/webapp/src/components/sidebar_left/index.js
+++ b/webapp/src/components/sidebar_left/index.js
@@ -1,0 +1,27 @@
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
+
+import {getCloudUserData} from '../../actions';
+
+import {getShowRHSAction, installsForUser} from '../../selectors';
+import SidebarLeft from './sidebar_left'
+
+function mapStateToProps(state) {
+    const id = getCurrentUserId(state);
+    return {
+        id,
+        installs: installsForUser(state, id),
+        showRHS: getShowRHSAction(state),
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getCloudUserData,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SidebarLeft);

--- a/webapp/src/components/sidebar_left/sidebar_left.jsx
+++ b/webapp/src/components/sidebar_left/sidebar_left.jsx
@@ -1,0 +1,60 @@
+
+
+import React, {useEffect} from 'react';
+
+import PropTypes from 'prop-types';
+import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
+import {Tooltip, OverlayTrigger} from 'react-bootstrap';
+
+
+const SidebarLeft = ({ id, installs, actions, showRHS, theme }) => {
+    useEffect(() => {
+        actions.getCloudUserData(id);
+    }, [id, actions]);
+    
+    const style = getStyle(theme);
+
+    return (
+        <div className='CloudPlugin__SidebarLeft'>
+            <OverlayTrigger
+                key='githubYourPrsLink'
+                placement={'right'}
+                
+                overlay={<Tooltip id='yourCloudInstallationsToolTip'>{'Your Cloud installations'}</Tooltip>}
+            >
+                <a
+                    data-testid={'yourCloudInstallationsTestId'}
+                    style={style}
+                    onClick={() => {
+                        console.log("Hey");
+                        showRHS(true);
+                    }}
+                >
+                    <i className='fa fa-cloud' />
+                    {' ' + installs.length}
+                </a>
+            </OverlayTrigger>
+        </div>
+    );
+};
+
+SidebarLeft.propTypes = {
+    id: PropTypes.string.isRequired,
+    installs: PropTypes.array.isRequired,
+    actions: PropTypes.shape({
+        getCloudUserData: PropTypes.func.isRequired,
+    }),
+    theme: PropTypes.object.isRequired,
+    showRHS: PropTypes.func.isRequired,
+}
+
+const getStyle = makeStyleFromTheme((theme) => {
+    return {
+        color: changeOpacity(theme.sidebarText, 0.6),
+        display: 'block',
+        marginBottom: '10px',
+        width: '100%',
+    };
+});
+
+export default SidebarLeft;

--- a/webapp/src/components/sidebar_left/sidebar_left.test.jsx
+++ b/webapp/src/components/sidebar_left/sidebar_left.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import SidebarLeft from './sidebar_left';
+
+jest.mock('mattermost-redux/utils/theme_utils', () => ({
+    makeStyleFromTheme: jest.fn((style) => style),
+    changeOpacity: jest.fn((color, opacity) => color),
+}));
+
+jest.mock('react-bootstrap', () => ({
+    Tooltip: jest.fn(({ children }) => children),
+    OverlayTrigger: jest.fn(({ children }) => children),
+}));
+
+describe('SidebarLeft', () => {
+    const id = 'user123';
+    const installs = [1, 2, 3];
+    const actions = {
+        getCloudUserData: jest.fn(),
+    };
+    const showRHS = jest.fn();
+    const theme = {
+        sidebarText: '#ffffff',
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render the component', () => {
+        const { getByTestId } = render(
+            <SidebarLeft id={id} installs={installs} actions={actions} showRHS={showRHS} theme={theme} />,
+        );
+
+        const tooltip = getByTestId('yourCloudInstallationsTestId');
+        expect(tooltip).toBeInTheDocument();
+    });
+
+    it('should call the showRHS function when the link is clicked', () => {
+        const { getByTestId } = render(
+            <SidebarLeft id={id} installs={installs} actions={actions} showRHS={showRHS} theme={theme} />,
+        );
+
+        fireEvent.click(getByTestId('yourCloudInstallationsTestId'));
+
+        expect(showRHS).toHaveBeenCalledWith(true);
+    });
+
+    it('should call the getCloudUserData action creator on mount', () => {
+        render(<SidebarLeft id={id} installs={installs} actions={actions} showRHS={showRHS} theme={theme} />);
+
+        expect(actions.getCloudUserData).toHaveBeenCalledWith(id);
+    });
+
+    it('should render the correct number of installs', () => {
+        const { getByText } = render(
+            <SidebarLeft id={id} installs={installs} actions={actions} showRHS={showRHS} theme={theme} />,
+        );
+
+        expect(getByText('3')).toBeInTheDocument();
+    });
+
+    it('should apply the correct style to the link', () => {
+        const { getByTestId } = render(
+            <SidebarLeft id={id} installs={installs} actions={actions} showRHS={showRHS} theme={theme} />,
+        );
+
+        const link = getByTestId('yourCloudInstallationsTestId');
+        expect(link).toHaveStyle('color: #ffffff');
+        expect(link).toHaveStyle('display: block');
+        expect(link).toHaveStyle('margin-bottom: 10px');
+        expect(link).toHaveStyle('width: 100%');
+    });
+});

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -5,12 +5,14 @@ import {id as pluginId} from './manifest';
 import {getPluginServerRoute, setShowRHSAction, telemetry} from './actions/index.js';
 import ChannelHeaderButton from './components/channel_header_button';
 import SidebarRight from './components/sidebar_right';
+import SidebarLeft from './components/sidebar_left'
 
 class Plugin {
     async initialize(registry, store) {
         registry.registerReducer(Reducer);
 
         registry.registerPopoverUserAttributesComponent(UserAttribute);
+        registry.registerBottomTeamSidebarComponent(SidebarLeft);
 
         const {toggleRHSPlugin, showRHSPlugin} = registry.registerRightHandSidebarComponent(SidebarRight, 'Cloud Plugin');
         store.dispatch(setShowRHSAction(() => store.dispatch(showRHSPlugin)));


### PR DESCRIPTION
#### Summary
Adds a button to the LHS team bar that displays your current count of installations as well as opens the RHS for the plugin when clicked. 


![image](https://github.com/mattermost/mattermost-plugin-cloud/assets/12176405/49eef530-7088-4791-a145-d601667d5b55)
![image](https://github.com/mattermost/mattermost-plugin-cloud/assets/12176405/44a2bac9-f8a0-498c-85a4-c4a38fceb58d)


#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6025
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
