### PR TITLE
Generate random passwords for installation credentials

### DIFF
--- a/server/setup.go
+++ b/server/setup.go
@@ -14,15 +14,13 @@ import (
 
 const (
 	defaultAdminUsername = "admin"
-	defaultAdminPassword = "Sys@dmin123"
 	defaultAdminEmail    = "success+sysadmin@simulator.amazonses.com"
 
 	defaultUserUsername = "user"
-	defaultUserPassword = "User@123"
 	defaultUserEmail    = "success+user@simulator.amazonses.com"
 )
 
-func (p *Plugin) setupInstallation(install *Installation) error {
+func (p *Plugin) setupInstallation(install *Installation, adminPassword, userPassword string) error {
 	if len(install.DNSRecords) == 0 {
 		return fmt.Errorf("Installation %s doesn't have any DNSRecords", install.ID)
 	}
@@ -37,7 +35,7 @@ func (p *Plugin) setupInstallation(install *Installation) error {
 		return errors.Wrap(err, "encountered an error waiting for installation DNS")
 	}
 
-	err = p.createAndLoginAdminUser(client)
+	err = p.createAndLoginAdminUser(client, adminPassword)
 	if err != nil {
 		return errors.Wrap(err, "encountered an error creating installation admin account")
 	}
@@ -48,7 +46,7 @@ func (p *Plugin) setupInstallation(install *Installation) error {
 	}
 
 	// Create normal user
-	err = p.createUser(client, defaultUserUsername, defaultUserPassword, defaultUserEmail)
+	err = p.createUser(client, defaultUserUsername, userPassword, defaultUserEmail)
 	if err != nil {
 		return errors.Wrap(err, "encountered an error creating installation user account")
 	}
@@ -82,13 +80,13 @@ func (p *Plugin) createUser(client *model.Client4, username, password, email str
 	return err
 }
 
-func (p *Plugin) createAndLoginAdminUser(client *model.Client4) error {
-	err := p.createUser(client, defaultAdminUsername, defaultAdminPassword, defaultAdminEmail)
+func (p *Plugin) createAndLoginAdminUser(client *model.Client4, password string) error {
+	err := p.createUser(client, defaultAdminUsername, password, defaultAdminEmail)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = client.Login(defaultAdminUsername, defaultAdminPassword)
+	_, _, err = client.Login(defaultAdminUsername, password)
 	if err != nil {
 		return err
 	}
@@ -183,4 +181,8 @@ func (p *Plugin) createTestData(client *model.Client4, install *Installation) er
 	}
 
 	return nil
+}
+
+func generateRandomPassword(prefix string) string {
+	return fmt.Sprintf("%s@%s", prefix, cloud.NewID())
 }

--- a/server/setup_test.go
+++ b/server/setup_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRandomPassword(t *testing.T) {
+	user1Pass := generateRandomPassword("user")
+
+	t.Run("user 1 password valid", func(t *testing.T) {
+		parts := strings.Split(user1Pass, "@")
+		require.Len(t, parts, 2)
+		assert.Equal(t, "user", parts[0])
+		assert.Len(t, parts[1], 26)
+	})
+
+	user2Pass := generateRandomPassword("user")
+
+	t.Run("user 2 password valid", func(t *testing.T) {
+		parts := strings.Split(user2Pass, "@")
+		require.Len(t, parts, 2)
+		assert.Equal(t, "user", parts[0])
+		assert.Len(t, parts[1], 26)
+	})
+
+	t.Run("user passwords differ", func(t *testing.T) {
+		require.NotEqual(t, user1Pass, user2Pass)
+	})
+
+	adminPass := generateRandomPassword("admin")
+
+	t.Run("admin prefix valid", func(t *testing.T) {
+		parts := strings.Split(adminPass, "@")
+		require.Len(t, parts, 2)
+		assert.Equal(t, "admin", parts[0])
+		assert.Len(t, parts[1], 26)
+	})
+}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -137,7 +137,9 @@ Installation details:
 		cloud.InstallationStateCreationFailed,
 		cloud.InstallationStateCreationFinalTasks:
 
-		err = p.setupInstallation(install)
+		adminPassword := generateRandomPassword(defaultAdminUsername)
+		userPassword := generateRandomPassword(defaultUserUsername)
+		err = p.setupInstallation(install, adminPassword, userPassword)
 		if err != nil {
 			p.API.LogError(err.Error(), "installation", install.Name)
 			return
@@ -176,7 +178,14 @@ Grafana logs for this installation:
 
 Installation details:
 %s
-`, install.Name, dnsRecord, defaultAdminUsername, defaultAdminPassword, defaultUserUsername, defaultUserPassword, installationLogsURL, provisionerLogsURL, jsonCodeBlock(install.ToPrettyJSON()))
+`,
+			install.Name,
+			dnsRecord,
+			inlineCode(defaultAdminUsername), inlineCode(adminPassword),
+			inlineCode(defaultUserUsername), inlineCode(userPassword),
+			installationLogsURL, provisionerLogsURL,
+			jsonCodeBlock(install.ToPrettyJSON()),
+		)
 
 		p.PostBotDM(install.OwnerID, message)
 	}


### PR DESCRIPTION
The admin and user accounts created by the cloud plugin now have randomized passwords with a minimum length of 27 characters.

The randomized bits come from our standard cloud ID generation logic.

Fixes https://mattermost.atlassian.net/browse/CLD-6474

```release-note
Generate random passwords for installation credentials
```
