### PR TITLE
[CLD-6468] Authorize Provisioner Webhooks. Add Deletion Unlock Confirmation Modal

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -32,6 +32,12 @@
                 "help_text": "The token required for authenticating with the AWS API Gateway."
             },
             {
+                "key": "ProvisioningServerWebhookSecret",
+                "display_name": "Webhook secret sent by the provisioning server",
+                "type": "text",
+                "help_text": "The secret used to verify that webhooks are coming from the provisioning server. Plugin will read from the X-MM-Cloud-Plugin-Auth HTTP header"
+            },
+            {
                 "key": "InstallationDNS",
                 "display_name": "Installation DNS",
                 "type": "text",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -68,6 +68,7 @@ type configuration struct {
 	InstallationDNS                           string
 	AllowedEmailDomain                        string
 	DeletionLockInstallationsAllowedPerPerson string
+	ProvisioningServerWebhookSecret           string
 
 	// License
 	E10License              string

--- a/webapp/src/components/sidebar_right/deletion_unlock_confirmation_modal.jsx
+++ b/webapp/src/components/sidebar_right/deletion_unlock_confirmation_modal.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Button, Modal } from 'react-bootstrap';
+import './deletion_unlock_confirmation_modal.scss'
+
+
+export default function DeletionUnlockConfirmationModal({visible, onConfirm, onCancel}) {
+    return (
+        <Modal
+            show={visible}
+            onHide = {onCancel}
+            onCancel={onCancel}
+            className={'CloudPluginUnlockDeletionConfirmationModal'}
+        >
+            <Modal.Header closeButton={false}>
+                <Modal.Title>Remove deletion lock?</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <p>
+                    Are you sure you want to remove the deletion lock? Doing so will add this installation back into the clean up pool, meaning it can be deleted.
+                </p>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    type="button"
+                    bsStyle="tertiary"
+                    onClick={onCancel}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    type="button"
+                    bsStyle="danger"
+                    onClick={onConfirm}
+                >
+                    Remove Lock
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    )
+}

--- a/webapp/src/components/sidebar_right/deletion_unlock_confirmation_modal.scss
+++ b/webapp/src/components/sidebar_right/deletion_unlock_confirmation_modal.scss
@@ -1,0 +1,19 @@
+.CloudPluginUnlockDeletionConfirmationModal {
+    .modal-content {
+        border: none;
+        border-radius: 8px;
+        .modal-header {
+            border: none;
+            border-bottom: 1px solid #e5e5e5;
+            background: var(--center-channel-bg);
+            .modal-title {
+                color: var(--center-channel-color);
+            }
+        }
+        .modal-footer {
+            border: none;
+            border-radius: 8px;
+        }
+    }
+
+}

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Scrollbars} from 'react-custom-scrollbars-2';
 import {Button, Label, DropdownButton, MenuItem} from 'react-bootstrap';
+import DeletionUnlockConfirmationModal from './deletion_unlock_confirmation_modal';
 
 export function renderView(props) {
     return (
@@ -52,6 +53,7 @@ export default class SidebarRight extends React.PureComponent {
 
         this.state = {
             deletionLockedInstallationId: null,
+            deletionConfirmationModal: {visible: false},
         };
     }
 
@@ -97,17 +99,23 @@ export default class SidebarRight extends React.PureComponent {
         );
     }
 
+    async handleDeletionUnlock(installation) {
+        await this.props.actions.deletionUnlockInstallation(installation.ID);
+        this.props.actions.getCloudUserData(this.props.id);
+        this.setState({deletionConfirmationModal: {visible: false}})
+    }
+
+    handleDeletionUnlockButtonClick(installation) {
+        this.setState({deletionConfirmationModal: {visible: true, onConfirm: () => this.handleDeletionUnlock(installation), onCancel: () => this.setState({deletionConfirmationModal: {visible: false}})}});
+    }
+
     deletionLockButton(installation) {
         const deletionLockedInstallationsIds = this.props.installs.filter((install) => install.DeletionLocked).map((install) => install.ID);
         if (deletionLockedInstallationsIds.includes(installation.ID)) {
             return (
                 <Button
                     className='btn btn-danger btn-sm'
-                    onClick={async () => {
-                        await this.props.actions.deletionUnlockInstallation(installation.ID);
-                        this.props.actions.getCloudUserData(this.props.id);
-                    }
-                    }
+                    onClick={() => this.handleDeletionUnlockButtonClick(installation)}
                 >{'Unlock Deletion'}
                 </Button>
             );
@@ -216,21 +224,26 @@ export default class SidebarRight extends React.PureComponent {
 
         return (
             <React.Fragment>
-                <Scrollbars
-                    autoHide={true}
-                    autoHideTimeout={500}
-                    autoHideDuration={500}
-                    renderThumbHorizontal={renderThumbHorizontal}
-                    renderThumbVertical={renderThumbVertical}
-                    renderView={renderView}
-                    className='SidebarRight'
-                >
-                    <div style={style.container}>
-                        <ul style={style.ul}>
-                            {entries}
-                        </ul>
-                    </div>
-                </Scrollbars>
+                <>
+                    {
+                        this.state.deletionConfirmationModal.visible && <DeletionUnlockConfirmationModal visible={this.state.deletionConfirmationModal.visible} onConfirm={this.state.deletionConfirmationModal.onConfirm} onCancel={this.state.deletionConfirmationModal.onCancel}/>
+                    }   
+                    <Scrollbars
+                        autoHide={true}
+                        autoHideTimeout={500}
+                        autoHideDuration={500}
+                        renderThumbHorizontal={renderThumbHorizontal}
+                        renderThumbVertical={renderThumbVertical}
+                        renderView={renderView}
+                        className='SidebarRight'
+                    >
+                        <div style={style.container}>
+                            <ul style={style.ul}>
+                                {entries}
+                            </ul>
+                        </div>
+                    </Scrollbars>
+                </>
             </React.Fragment>
         );
     }


### PR DESCRIPTION


#### Summary
This PR includes 2 changes. 

1. Support for a new config value `ProvisioningServerWebhookSecret` which can be set in the system console. The plugin will now check for an HTTP header `X-MM-Cloud-Plugin-Auth-Token` with the value set for `ProvisioningServerWebhookSecret`, returning a `401` in the event they do not match. 
2. When clicking "Unlock Deletion" you will now see a modal like the following confirming your intentions:
3. 
![image](https://github.com/mattermost/mattermost-plugin-cloud/assets/12176405/31f3e2bc-6a22-463b-b585-4b1d678b3acd)


#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6468

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
