### PR TITLE
Log wrapErr to avoid panic

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -100,7 +100,7 @@ func (p *Plugin) handleUserInstalls(w http.ResponseWriter, r *http.Request) {
 	for _, install := range installsForUser {
 		webInstall, wrapErr := CreateInstallationWebWrapper(install)
 		if wrapErr != nil {
-			p.API.LogError(errors.Wrapf(err, "Unable to CreateInstallationWebWrapper for %s", install.Name).Error())
+			p.API.LogError(errors.Wrapf(wrapErr, "Unable to CreateInstallationWebWrapper for %s", install.Name).Error())
 			continue
 		}
 		webInstalls = append(webInstalls, webInstall)


### PR DESCRIPTION
The wrong error value was logged which could be `nil`.

Fixes https://mattermost.atlassian.net/browse/CLD-6522

```release-note
Log wrapErr to avoid panic
```
