### PR TITLE
Add installation restart command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -29,6 +29,9 @@ update [name] [flags]
 %s
 	example: /cloud update myinstallation --version 7.8.1
 
+restart [name]
+	Restarts the servers in a Mattermost installation.
+
 hibernate [name]
 	Hibernates a Mattermost installation.
 
@@ -118,6 +121,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		handler = p.runUpgradeHelperCommand
 	case "update":
 		handler = p.runUpdateCommand
+	case "restart":
+		handler = p.runRestartCommand
 	case "hibernate":
 		handler = p.runHibernateCommand
 	case "wake-up":

--- a/server/command_restart.go
+++ b/server/command_restart.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/pkg/errors"
+)
+
+func (p *Plugin) runRestartCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	if len(args) == 0 || len(args[0]) == 0 {
+		return nil, true, errors.New("must provide an installation name")
+	}
+
+	name := standardizeName(args[0])
+
+	installs, _, err := p.getInstallations()
+	if err != nil {
+		return nil, false, err
+	}
+
+	var installToRestart *Installation
+	for _, install := range installs {
+		if install.OwnerID == extra.UserId && standardizeName(install.Name) == name {
+			installToRestart = install
+			break
+		}
+	}
+
+	if installToRestart == nil {
+		return nil, true, errors.Errorf("no installation with the name %s found", name)
+	}
+
+	// We can force a restart by changing any environment variable, so we will
+	// set something arbitrary with the current date and time.
+	patch := &cloud.PatchInstallationRequest{MattermostEnv: cloud.EnvVarMap{
+		"CLOUD_PLUGIN_RESTART": cloud.EnvVar{Value: cloud.DateTimeStringFromMillis(cloud.GetMillis())},
+	}}
+	_, err = p.cloudClient.UpdateInstallation(installToRestart.ID, patch)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return getCommandResponse(model.CommandResponseTypeEphemeral, fmt.Sprintf("Installation %s restarting now.", name), extra), false, nil
+}

--- a/server/command_restart_test.go
+++ b/server/command_restart_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestartCommand(t *testing.T) {
+	plugin := Plugin{}
+	plugin.cloudClient = &MockClient{}
+
+	api := &plugintest.API{}
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	plugin.SetAPI(api)
+
+	t.Run("restart installation successfully", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runRestartCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Nil(t, err)
+		assert.False(t, isUserError)
+		assert.True(t, strings.Contains(resp.Text, "Installation gabesinstall restarting now."))
+	})
+
+	t.Run("restart installation successfully with caps in name to demonstrate name case insensitivity", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"GabesInstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runRestartCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Nil(t, err)
+		assert.False(t, isUserError)
+		assert.True(t, strings.Contains(resp.Text, "Installation gabesinstall restarting now."))
+	})
+
+	t.Run("don't restart with wrong owner", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runRestartCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid2"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "no installation with the name gabesinstall found"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+
+		resp, isUserError, err := plugin.runRestartCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid2"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "no installation with the name gabesinstall found"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no name provided", func(t *testing.T) {
+		resp, isUserError, err := plugin.runRestartCommand([]string{}, &model.CommandArgs{UserId: "gabeid"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "must provide an installation name"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+
+		resp, isUserError, err = plugin.runRestartCommand([]string{""}, &model.CommandArgs{UserId: "gabeid"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "must provide an installation name"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+}


### PR DESCRIPTION
The command will roll all server pods with an arbitrary env var update.

Fixes https://mattermost.atlassian.net/browse/CLD-6542

```release-note
Add installation restart command
```
