### PR TITLE
Display Service Environment configuration in RHS

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -224,5 +224,5 @@ func getInstallationServiceEnvironment(installation *Installation) string {
 		return v.Value
 	}
 
-	return "not-defined"
+	return "production"
 }

--- a/server/api.go
+++ b/server/api.go
@@ -103,9 +103,9 @@ func (p *Plugin) handleUserInstalls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	installsForUser, err := p.getUpdatedInstallsForUser(req.UserID, false)
+	installsForUser, err := p.getUpdatedInstallsForUserWithSensitive(req.UserID)
 	if err != nil {
-		p.API.LogError(errors.Wrap(err, "Unable to getUpdatedInstallsForUser").Error())
+		p.API.LogError(errors.Wrap(err, "Unable to getUpdatedInstallsForUserWithSensitive").Error())
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/server/command_deletion_lock.go
+++ b/server/command_deletion_lock.go
@@ -12,7 +12,7 @@ func (p *Plugin) lockForDeletion(installationID string, userID string) error {
 	if installationID == "" {
 		return errors.New("installationID must not be empty")
 	}
-	installations, err := p.getUpdatedInstallsForUser(userID, true)
+	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(userID)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (p *Plugin) unlockForDeletion(installationID string, userID string) error {
 		return errors.New("installationID must not be empty")
 	}
 
-	installations, err := p.getUpdatedInstallsForUser(userID, true)
+	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(userID)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (p *Plugin) runDeletionLockCommand(args []string, extra *model.CommandArgs)
 
 	name := standardizeName(args[0])
 
-	installations, err := p.getUpdatedInstallsForUser(extra.UserId, true)
+	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
 	if err != nil {
 		return nil, true, err
 	}
@@ -118,7 +118,7 @@ func (p *Plugin) runDeletionUnlockCommand(args []string, extra *model.CommandArg
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUser(extra.UserId, true)
+	installs, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
 	if err != nil {
 		return nil, false, err
 	}

--- a/server/command_deletion_lock.go
+++ b/server/command_deletion_lock.go
@@ -12,7 +12,7 @@ func (p *Plugin) lockForDeletion(installationID string, userID string) error {
 	if installationID == "" {
 		return errors.New("installationID must not be empty")
 	}
-	installations, err := p.getUpdatedInstallsForUser(userID)
+	installations, err := p.getUpdatedInstallsForUser(userID, true)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (p *Plugin) unlockForDeletion(installationID string, userID string) error {
 		return errors.New("installationID must not be empty")
 	}
 
-	installations, err := p.getUpdatedInstallsForUser(userID)
+	installations, err := p.getUpdatedInstallsForUser(userID, true)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (p *Plugin) runDeletionLockCommand(args []string, extra *model.CommandArgs)
 
 	name := standardizeName(args[0])
 
-	installations, err := p.getUpdatedInstallsForUser(extra.UserId)
+	installations, err := p.getUpdatedInstallsForUser(extra.UserId, true)
 	if err != nil {
 		return nil, true, err
 	}
@@ -118,7 +118,7 @@ func (p *Plugin) runDeletionUnlockCommand(args []string, extra *model.CommandArg
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUser(extra.UserId)
+	installs, err := p.getUpdatedInstallsForUser(extra.UserId, true)
 	if err != nil {
 		return nil, false, err
 	}

--- a/server/command_hibernate.go
+++ b/server/command_hibernate.go
@@ -16,7 +16,7 @@ func (p *Plugin) runHibernateCommand(args []string, extra *model.CommandArgs) (*
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUser(extra.UserId)
+	installs, err := p.getUpdatedInstallsForUser(extra.UserId, true)
 	if err != nil {
 		return nil, false, err
 	}

--- a/server/command_hibernate.go
+++ b/server/command_hibernate.go
@@ -16,7 +16,7 @@ func (p *Plugin) runHibernateCommand(args []string, extra *model.CommandArgs) (*
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUser(extra.UserId, true)
+	installs, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
 	if err != nil {
 		return nil, false, err
 	}

--- a/server/command_list.go
+++ b/server/command_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
-	installsForUser, err := p.getUpdatedInstallsForUser(extra.UserId, true)
+	installsForUser, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
 	if err != nil {
 		return nil, false, err
 	}
@@ -25,6 +25,14 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (*model
 	}
 
 	return getCommandResponse(model.CommandResponseTypeEphemeral, jsonCodeBlock(prettyPrintJSON(string(data))), extra), false, nil
+}
+
+func (p *Plugin) getUpdatedInstallsForUserWithSensitive(userID string) ([]*Installation, error) {
+	return p.getUpdatedInstallsForUser(userID, false)
+}
+
+func (p *Plugin) getUpdatedInstallsForUserWithoutSensitive(userID string) ([]*Installation, error) {
+	return p.getUpdatedInstallsForUser(userID, true)
 }
 
 func (p *Plugin) getUpdatedInstallsForUser(userID string, hideSensitive bool) ([]*Installation, error) {

--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -23,8 +23,9 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 			mockedCloudInstallationsDTO: []*cloud.InstallationDTO{
 				{
 					Installation: &cloud.Installation{
-						ID:    "id1",
-						State: cloud.InstallationStateStable,
+						ID:            "id1",
+						State:         cloud.InstallationStateStable,
+						MattermostEnv: cloud.EnvVarMap{"secret": cloud.EnvVar{Value: "supersecret"}},
 					},
 				},
 				{
@@ -54,6 +55,33 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 
 	plugin.SetAPI(api)
 
+	t.Run("test sensitivity", func(t *testing.T) {
+		pluginInstalls, installationBytes, err := getFakePluginInstallations()
+		require.NoError(t, err)
+		api.On("KVGet", mock.AnythingOfType("string")).Return(installationBytes, nil)
+		api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+		api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.Channel{}, nil)
+		api.On("CreatePost", mock.Anything).Return(nil, nil)
+		api.On("LogWarn", mock.AnythingOfTypeArgument("string")).Return(nil)
+
+		t.Run("with sensitive", func(t *testing.T) {
+			installations, err := plugin.getUpdatedInstallsForUserWithSensitive("owner 1")
+			require.NoError(t, err)
+			require.Equal(t, len(pluginInstalls), len(installations))
+			assert.Equal(t, "id1", installations[0].ID)
+			assert.NotNil(t, installations[0].MattermostEnv)
+			t.Log(installations[0].State)
+		})
+
+		t.Run("without sensitive", func(t *testing.T) {
+			installations, err := plugin.getUpdatedInstallsForUserWithoutSensitive("owner 1")
+			require.NoError(t, err)
+			require.Equal(t, len(pluginInstalls), len(installations))
+			assert.Equal(t, "id1", installations[0].ID)
+			assert.Nil(t, installations[0].MattermostEnv)
+		})
+	})
+
 	t.Run("test deleted installations", func(t *testing.T) {
 		pluginInstalls, installationBytes, err := getFakePluginInstallations()
 		require.NoError(t, err)
@@ -63,7 +91,7 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 		api.On("CreatePost", mock.Anything).Return(nil, nil)
 		api.On("LogWarn", mock.AnythingOfTypeArgument("string")).Return(nil)
 
-		installations, err := plugin.getUpdatedInstallsForUser("owner 1", true)
+		installations, err := plugin.getUpdatedInstallsForUserWithoutSensitive("owner 1")
 		require.NoError(t, err)
 		require.Equal(t, len(pluginInstalls), len(installations))
 		assert.Equal(t, "id1", installations[0].ID)

--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -63,7 +63,7 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 		api.On("CreatePost", mock.Anything).Return(nil, nil)
 		api.On("LogWarn", mock.AnythingOfTypeArgument("string")).Return(nil)
 
-		installations, err := plugin.getUpdatedInstallsForUser("owner 1")
+		installations, err := plugin.getUpdatedInstallsForUser("owner 1", true)
 		require.NoError(t, err)
 		require.Equal(t, len(pluginInstalls), len(installations))
 		assert.Equal(t, "id1", installations[0].ID)

--- a/server/command_wakeup.go
+++ b/server/command_wakeup.go
@@ -16,7 +16,7 @@ func (p *Plugin) runWakeUpCommand(args []string, extra *model.CommandArgs) (*mod
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUser(extra.UserId)
+	installs, err := p.getUpdatedInstallsForUser(extra.UserId, true)
 	if err != nil {
 		return nil, false, err
 	}

--- a/server/command_wakeup.go
+++ b/server/command_wakeup.go
@@ -16,7 +16,7 @@ func (p *Plugin) runWakeUpCommand(args []string, extra *model.CommandArgs) (*mod
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUser(extra.UserId, true)
+	installs, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
 	if err != nil {
 		return nil, false, err
 	}

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -218,6 +218,14 @@ export default class SidebarRight extends React.PureComponent {
                         <span style={style.col1}>Size:</span>
                         <span>{install.Size}</span>
                     </div>
+                    <div>
+                        <span style={style.col1}>Service Env:</span>
+                        <span>{install.ServiceEnvironment}</span>
+                    </div>
+                    <div>
+                        <span style={style.col1}>Created:</span>
+                        <span>{install.CreateAtDate}</span>
+                    </div>
                 </div>
                 {this.installationButtons(install)}
             </li>


### PR DESCRIPTION
This change is the first step in better handling of service environment configuration in the plugin. The installation environment variables are now examined to expose which service environment value the test server will use. This is displayed in the plugin RHS. The creation date of the server is now also displayed for informational purposes.

Fixes https://mattermost.atlassian.net/browse/CLD-6553

<img width="360" alt="Screenshot 2023-11-03 at 11 03 00 AM" src="https://github.com/mattermost/mattermost-plugin-cloud/assets/3694686/55300942-809c-46d2-877c-a5d28a189931">

```release-note
Display Service Environment configuration in RHS
```
