### PR TITLE
Add Installation Sharing

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -29,6 +29,17 @@ update [name] [flags]
 %s
 	example: /cloud update myinstallation --version 7.8.1
 
+share [name] [flags]
+	Share a Mattermost installation with other plugin users.
+	Flags:
+%s
+	example: /cloud share myinstallation --allow-updates=true
+
+unshare [name] [flags]
+	Remove the shared setting from an installation that is already shared.
+
+	example: /cloud unshare myinstallation
+
 restart [name]
 	Restarts the servers in a Mattermost installation.
 
@@ -60,6 +71,7 @@ info
 		help,
 		p.getCreateFlagSet().FlagUsages(),
 		getUpdateFlagSet().FlagUsages(),
+		getShareFlagSet().FlagUsages(),
 	))
 }
 
@@ -126,6 +138,10 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		handler = p.runInfoCommand
 	case "import":
 		handler = p.runImportCommand
+	case "share":
+		handler = p.runShareInstallationCommand
+	case "unshare":
+		handler = p.runUnshareInstallationCommand
 	case "deletion-lock":
 		handler = p.runDeletionLockCommand
 	case "deletion-unlock":

--- a/server/command_share.go
+++ b/server/command_share.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/pkg/errors"
+	flag "github.com/spf13/pflag"
+)
+
+type shareConfig struct {
+	AllowUpdates bool
+}
+
+func getShareFlagSet() *flag.FlagSet {
+	flagSet := flag.NewFlagSet("share", flag.ContinueOnError)
+	flagSet.Bool("allow-updates", false, "Allow other plugin users to update the installation configuration")
+
+	return flagSet
+}
+
+func parseShareFlagSet(args []string) (*shareConfig, error) {
+	flagSet := getShareFlagSet()
+	err := flagSet.Parse(args)
+	if err != nil {
+		return nil, errors.Wrap(err, "falied to parse flags")
+	}
+
+	config := &shareConfig{}
+	config.AllowUpdates, err = flagSet.GetBool("allow-updates")
+	if err != nil {
+		return nil, errors.Wrap(err, "falied to get allow-updates value")
+	}
+
+	return config, nil
+}
+
+func (p *Plugin) runShareInstallationCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	if len(args) == 0 || len(args[0]) == 0 {
+		return nil, true, errors.Errorf("must provide an installation name")
+	}
+
+	name := standardizeName(args[0])
+
+	config, err := parseShareFlagSet(args)
+	if err != nil {
+		return nil, true, err
+	}
+
+	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	if err != nil {
+		return nil, true, err
+	}
+	var installationToShare *Installation
+	for _, installation := range installations {
+		if installation.OwnerID == extra.UserId && installation.Name == name {
+			installationToShare = installation
+			break
+		}
+	}
+
+	if installationToShare == nil {
+		return nil, true, errors.Errorf("no installation with the name %s found", name)
+	}
+
+	installationToShare.Shared = true
+	installationToShare.AllowSharedUpdates = config.AllowUpdates
+	err = p.updateInstallation(installationToShare)
+	if err != nil {
+		return getCommandResponse(model.CommandResponseTypeEphemeral, err.Error(), extra), false, err
+	}
+
+	sharedUpdateText := "Other plugin users are not permitted to update this installation."
+	if config.AllowUpdates {
+		sharedUpdateText = "Other plugin users will be allowed to update this installation."
+	}
+	return getCommandResponse(model.CommandResponseTypeEphemeral, fmt.Sprintf("Installation has been shared with other plugin users. %s", sharedUpdateText), extra), false, nil
+}
+
+func (p *Plugin) runUnshareInstallationCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	if len(args) == 0 || len(args[0]) == 0 {
+		return nil, true, errors.Errorf("must provide an installation name")
+	}
+
+	name := standardizeName(args[0])
+
+	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	if err != nil {
+		return nil, true, err
+	}
+	var installationToShare *Installation
+	for _, installation := range installations {
+		if installation.OwnerID == extra.UserId && installation.Name == name {
+			installationToShare = installation
+			break
+		}
+	}
+
+	if installationToShare == nil {
+		return nil, true, errors.Errorf("no installation with the name %s found", name)
+	}
+
+	installationToShare.Shared = false
+	installationToShare.AllowSharedUpdates = false
+	err = p.updateInstallation(installationToShare)
+	if err != nil {
+		return getCommandResponse(model.CommandResponseTypeEphemeral, err.Error(), extra), false, err
+	}
+
+	return getCommandResponse(model.CommandResponseTypeEphemeral, "Installation has been unshared.", extra), false, nil
+}

--- a/server/command_share_test.go
+++ b/server/command_share_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"testing"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShareCommand(t *testing.T) {
+	dockerClient := &MockedDockerClient{tagExists: true}
+	mockCloudClient := &MockClient{
+		mockedCloudInstallationsDTO: []*cloud.InstallationDTO{
+			{Installation: &cloud.Installation{ID: "someid", OwnerID: "gabeid"}},
+		},
+	}
+	plugin := Plugin{
+		cloudClient:  mockCloudClient,
+		dockerClient: dockerClient,
+	}
+
+	api := &plugintest.API{}
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+	plugin.SetAPI(api)
+
+	t.Run("share installation successfully", func(t *testing.T) {
+		resp, isUserError, err := plugin.runShareInstallationCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation has been shared with other plugin users. Other plugin users are not permitted to update this installation.")
+	})
+
+	t.Run("share installation successfully with name with caps to demonstrate case insensitivity of name", func(t *testing.T) {
+		resp, isUserError, err := plugin.runShareInstallationCommand([]string{"GabesInstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation has been shared with other plugin users. Other plugin users are not permitted to update this installation.")
+	})
+
+	t.Run("share installation successfully and allow updates", func(t *testing.T) {
+		resp, isUserError, err := plugin.runShareInstallationCommand([]string{"gabesinstall", "--allow-updates"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation has been shared with other plugin users. Other plugin users will be allowed to update this installation.")
+	})
+
+	t.Run("missing installation name", func(t *testing.T) {
+		resp, isUserError, err := plugin.runShareInstallationCommand([]string{}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must provide an installation name")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("invalid installation name", func(t *testing.T) {
+		resp, isUserError, err := plugin.runShareInstallationCommand([]string{"gabesinstall2"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no installation with the name gabesinstall2 found")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestUnshareCommand(t *testing.T) {
+	dockerClient := &MockedDockerClient{tagExists: true}
+	mockCloudClient := &MockClient{
+		mockedCloudInstallationsDTO: []*cloud.InstallationDTO{
+			{Installation: &cloud.Installation{ID: "someid", OwnerID: "gabeid"}},
+		},
+	}
+	plugin := Plugin{
+		cloudClient:  mockCloudClient,
+		dockerClient: dockerClient,
+	}
+
+	api := &plugintest.API{}
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+	plugin.SetAPI(api)
+
+	t.Run("unshare installation successfully", func(t *testing.T) {
+		resp, isUserError, err := plugin.runUnshareInstallationCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation has been unshared.")
+	})
+
+	t.Run("share installation successfully with name with caps to demonstrate case insensitivity of name", func(t *testing.T) {
+		resp, isUserError, err := plugin.runUnshareInstallationCommand([]string{"GabesInstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Installation has been unshared.")
+	})
+
+	t.Run("missing installation name", func(t *testing.T) {
+		resp, isUserError, err := plugin.runUnshareInstallationCommand([]string{}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must provide an installation name")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("invalid installation name", func(t *testing.T) {
+		resp, isUserError, err := plugin.runUnshareInstallationCommand([]string{"gabesinstall2"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no installation with the name gabesinstall2 found")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+}

--- a/webapp/src/action_types/index.js
+++ b/webapp/src/action_types/index.js
@@ -1,6 +1,7 @@
 import {id as pluginId} from '../manifest';
 
 export const RECEIVED_USER_INSTALLS = pluginId + '_received_user_installs';
+export const RECEIVED_SHARED_INSTALLS = pluginId + '_received_shared_installs';
 export const RECEIVED_SHOW_RHS_ACTION = pluginId + '_show_rhs';
 export const SET_RHS_VISIBLE = pluginId + '_set_rhs_visible';
 export const SET_SERVER_ERROR = pluginId + '_set_server_error';

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -10,6 +10,7 @@ import {installsForUser, serverError} from 'selectors';
 
 import {
     RECEIVED_USER_INSTALLS,
+    RECEIVED_SHARED_INSTALLS,
     RECEIVED_SHOW_RHS_ACTION,
     SET_RHS_VISIBLE,
     SET_SERVER_ERROR,
@@ -117,6 +118,29 @@ export function getCloudUserData(userID) {
         dispatch({
             type: RECEIVED_USER_INSTALLS,
             userID,
+            data,
+        });
+
+        return {data};
+    };
+}
+
+export function getSharedInstalls() {
+    return async (dispatch, getState) => {
+        const data = await Client.getSharedInstalls();
+
+        if (data.error) {
+            dispatch(setServerError(`Status: ${data.error.status}, Message: ${data.error.message}`));
+            return data;
+        }
+
+        // Clear server error
+        if (serverError(getState())) {
+            dispatch(setServerError(''));
+        }
+
+        dispatch({
+            type: RECEIVED_SHARED_INSTALLS,
             data,
         });
 

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -10,6 +10,8 @@ export default class Client {
         return this.doPost(`${this.url}/userinstalls`, JSON.stringify({user_id: userID}));
     };
 
+    getSharedInstalls = async () => this.doGet(`${this.url}/sharedinstalls`);
+
     deletionLockInstallation = async (installationID) => this.doPost(`${this.url}/deletion-lock`, JSON.stringify({installation_id: installationID}));
 
     deletionUnlockInstallation = async (installationID) => this.doPost(`${this.url}/deletion-unlock`, JSON.stringify({installation_id: installationID}));

--- a/webapp/src/components/sidebar_right/index.js
+++ b/webapp/src/components/sidebar_right/index.js
@@ -5,9 +5,9 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 
-import {telemetry, setRhsVisible, getCloudUserData, deletionLockInstallation, deletionUnlockInstallation, getPluginConfiguration} from '../../actions';
+import {telemetry, setRhsVisible, getCloudUserData, getSharedInstalls, deletionLockInstallation, deletionUnlockInstallation, getPluginConfiguration} from '../../actions';
 
-import {installsForUser, serverError, pluginConfiguration} from '../../selectors';
+import {installsForUser, sharedInstalls, serverError, pluginConfiguration} from '../../selectors';
 
 import SidebarRight from './sidebar_right.jsx';
 
@@ -16,6 +16,7 @@ function mapStateToProps(state) {
     return {
         id,
         installs: installsForUser(state, id),
+        sharedInstalls: sharedInstalls(state),
         serverError: serverError(state),
         maxLockedInstallations: parseInt(pluginConfiguration(state).DeletionLockInstallationsAllowedPerPerson, 10),
     };
@@ -26,6 +27,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             telemetry,
             getCloudUserData,
+            getSharedInstalls,
             setVisible: setRhsVisible,
             deletionLockInstallation,
             deletionUnlockInstallation,

--- a/webapp/src/components/sidebar_right/sidebar_right.test.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.test.jsx
@@ -36,6 +36,22 @@ describe('SidebarRight', () => {
                 DeletionLocked: true,
             },
         ],
+        sharedInstalls: [
+            {
+                ID: '3',
+                Name: 'Test Installation 3',
+                State: 'stable',
+                DNSRecords: [{DomainName: 'test3.example.com'}],
+                Image: 'test-image',
+                Tag: '',
+                Database: 'test-db',
+                Filestore: 'test-filestore',
+                Size: 'test-size',
+                InstallationLogsURL: 'https://test3.example.com/logs',
+                ProvisionerLogsURL: 'https://test3.example.com/provisioner-logs',
+                DeletionLocked: false,
+            },
+        ],
         serverError: '',
         deletionLockedInstallationId: null,
         maxLockedInstallations: 1,
@@ -43,6 +59,7 @@ describe('SidebarRight', () => {
             setVisible: jest.fn(),
             telemetry: jest.fn(),
             getCloudUserData: jest.fn(),
+            getSharedInstalls: jest.fn(),
             deletionLockInstallation: jest.fn(),
             deletionUnlockInstallation: jest.fn(),
             getPluginConfiguration: jest.fn(),
@@ -63,7 +80,7 @@ describe('SidebarRight', () => {
         const propsWithNoInstalls = {...props, installs: []};
         render(<SidebarRight {...propsWithNoInstalls}/>);
 
-        const message = screen.getByText('There are no installations, use the /cloud create command to add an installation.');
+        const message = screen.getByText('There are no installations. Use the `/cloud create` command to add an installation.');
 
         expect(message).toBeInTheDocument();
     });
@@ -93,10 +110,11 @@ describe('SidebarRight', () => {
         expect(props.actions.setVisible).toHaveBeenCalledWith(false);
     });
 
-    it('calls the getCloudUserData and getPluginConfiguration actions on mount', () => {
+    it('calls the getCloudUserData, getSharedInstalls, and getPluginConfiguration actions on mount', () => {
         render(<SidebarRight {...props}/>);
 
         expect(props.actions.getCloudUserData).toHaveBeenCalledWith('test-id');
+        expect(props.actions.getSharedInstalls).toHaveBeenCalled();
         expect(props.actions.getPluginConfiguration).toHaveBeenCalled();
     });
 
@@ -140,5 +158,28 @@ describe('SidebarRight', () => {
 
         expect(props.actions.deletionLockInstallation).not.toHaveBeenCalledWith('2');
         expect(lockButton2).toBeDisabled();
+    });
+
+    it('renders a list of shared installations', () => {
+        render(<SidebarRight {...props}/>);
+
+        const sharedServerButton = screen.getByText('Shared');
+        fireEvent.click(sharedServerButton);
+
+        const installation3 = screen.getByText('Test Installation 3');
+
+        expect(installation3).toBeInTheDocument();
+    });
+
+    it('displays a message when there are no shared installations', () => {
+        const propsWithNoSharedInstalls = {...props, sharedInstalls: []};
+        render(<SidebarRight {...propsWithNoSharedInstalls}/>);
+
+        const sharedServerButton = screen.getByText('Shared');
+        fireEvent.click(sharedServerButton);
+
+        const message = screen.getByText('There are no shared installations. Use the `/cloud share` command to share one of yours with other plugin users.');
+
+        expect(message).toBeInTheDocument();
     });
 });

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -1,6 +1,6 @@
 import {combineReducers} from 'redux';
 
-import {RECEIVED_USER_INSTALLS, RECEIVED_SHOW_RHS_ACTION, SET_RHS_VISIBLE, SET_SERVER_ERROR, RECEIVED_CONFIG} from '../action_types';
+import {RECEIVED_USER_INSTALLS, RECEIVED_SHARED_INSTALLS, RECEIVED_SHOW_RHS_ACTION, SET_RHS_VISIBLE, SET_SERVER_ERROR, RECEIVED_CONFIG} from '../action_types';
 
 function cloudUserInstalls(state = {}, action) {
     switch (action.type) {
@@ -9,6 +9,15 @@ function cloudUserInstalls(state = {}, action) {
         nextState[action.userID] = action.data;
         return nextState;
     }
+    default:
+        return state;
+    }
+}
+
+function sharedInstalls(state = [], action) {
+    switch (action.type) {
+    case RECEIVED_SHARED_INSTALLS:
+        return action.data;
     default:
         return state;
     }
@@ -52,6 +61,7 @@ function serverError(state = '', action) {
 
 export default combineReducers({
     cloudUserInstalls,
+    sharedInstalls,
     rhsPluginAction,
     isRhsVisible,
     serverError,

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -3,8 +3,9 @@ import {id as pluginId} from './manifest';
 const getPluginState = (state) => state['plugins-' + pluginId] || {};
 
 export const installsForUser = (state, id) => getPluginState(state).cloudUserInstalls[id] || [];
-export const getShowRHSAction = (state) => getPluginState(state).rhsPluginAction;
+export const sharedInstalls = (state) => getPluginState(state).sharedInstalls || [];
 export const pluginConfiguration = (state) => getPluginState(state).pluginConfiguration;
 
+export const getShowRHSAction = (state) => getPluginState(state).rhsPluginAction;
 export const isRhsVisible = (state) => getPluginState(state).isRhsVisible;
 export const serverError = (state) => getPluginState(state).serverError;


### PR DESCRIPTION
Installation sharing can be used by installation owners to make an installation more visible to other plugin users. This can be helpful when a shared instance is being used for development work or testing by multiple people.

Optionally, the installation owner can allow other plugin users to issue update commands to the shared instance for more-seamless cooperation. The installation owners will receive a message from the cloud bot when another user updates their shared installation.

Installation sharing is handled via `/cloud share` and `cloud unshare` commands. When shared, installations can be viewed by other plugin users in the RHS via the server type toggle at the top.

<img width="500" alt="Screenshot 2023-12-08 at 12 31 13 PM" src="https://github.com/mattermost/mattermost-plugin-cloud/assets/3694686/636609d3-72b8-443d-93f4-aa1511370516">

Fixes https://mattermost.atlassian.net/browse/CLD-6788

```release-note
Add Installation Sharing
```
