### PR TITLE
Add option to list shared servers

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -19,6 +19,7 @@ create [name] [flags]
 
 list
 	Lists the Mattermost installations created by you.
+%s
 
 import [DNS]
 	Imports installation using DNS value.
@@ -70,6 +71,7 @@ info
 	return codeBlock(fmt.Sprintf(
 		help,
 		p.getCreateFlagSet().FlagUsages(),
+		getListFlagSet().FlagUsages(),
 		getUpdateFlagSet().FlagUsages(),
 		getShareFlagSet().FlagUsages(),
 	))

--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -150,4 +150,13 @@ func TestListCommand(t *testing.T) {
 		assert.False(t, isUserError)
 		assert.False(t, strings.Contains(resp.Text, "someid"))
 	})
+
+	t.Run("no shared installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\"}]"), nil)
+
+		resp, isUserError, err := plugin.runListCommand([]string{"--shared-installations"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Nil(t, err)
+		assert.False(t, isUserError)
+		assert.True(t, strings.Contains(resp.Text, "No installations found."))
+	})
 }


### PR DESCRIPTION
The change adds a flag to `/cloud list` to allow for listing the details of shared servers managed by the plugin.

Fixes https://mattermost.atlassian.net/browse/CLD-6813

```release-note
Add option to list shared servers
```
