### PR TITLE
Add installation restart button to UI

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -176,6 +176,16 @@ export const getPluginServerRoute = (state) => {
 
     return basePath + '/plugins/' + pluginId;
 };
+
+export function restartInstallation(name) {
+    return async (dispatch, getState) => {
+        const command = `/cloud restart ${name}`;
+        await Client.clientExecuteCommand(getState, command);
+
+        return {data: null};
+    };
+}
+
 export const telemetry = (event, properties) => async (dispatch, getState) => {
     await fetch(getPluginServerRoute(getState()) + '/telemetry', Client4.getOptions({
         method: 'post',

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -1,6 +1,8 @@
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {Client4} from 'mattermost-redux/client';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import Client from '../client';
 
@@ -177,13 +179,19 @@ export const getPluginServerRoute = (state) => {
     return basePath + '/plugins/' + pluginId;
 };
 
-export function restartInstallation(name) {
+export function executeCommand(command) {
     return async (dispatch, getState) => {
-        const command = `/cloud restart ${name}`;
-        await Client.clientExecuteCommand(getState, command);
+        const currentChannelID = getCurrentChannel(getState()).id;
+        const currentTeamID = getCurrentTeamId(getState());
+
+        await Client.clientExecuteCommand(command, currentChannelID, currentTeamID);
 
         return {data: null};
     };
+}
+
+export function restartInstallation(name) {
+    return executeCommand(`/cloud restart ${name}`);
 }
 
 export const telemetry = (event, properties) => async (dispatch, getState) => {

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -1,7 +1,5 @@
 import {Client4} from 'mattermost-redux/client';
 import {ClientError} from 'mattermost-redux/client/client4';
-import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 export default class Client {
     constructor() {
@@ -98,13 +96,10 @@ export default class Client {
         });
     };
 
-    clientExecuteCommand = async (getState, command) => {
-        const currentChannel = getCurrentChannel(getState());
-        const currentTeamId = getCurrentTeamId(getState());
-
+    clientExecuteCommand = async (command, channelID, teamID) => {
         const args = {
-            channel_id: currentChannel.id,
-            team_id: currentTeamId,
+            channel_id: channelID,
+            team_id: teamID,
         };
 
         try {

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -1,5 +1,7 @@
 import {Client4} from 'mattermost-redux/client';
 import {ClientError} from 'mattermost-redux/client/client4';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 export default class Client {
     constructor() {
@@ -94,5 +96,21 @@ export default class Client {
             },
             body,
         });
+    };
+
+    clientExecuteCommand = async (getState, command) => {
+        const currentChannel = getCurrentChannel(getState());
+        const currentTeamId = getCurrentTeamId(getState());
+
+        const args = {
+            channel_id: currentChannel.id,
+            team_id: currentTeamId,
+        };
+
+        try {
+            await Client4.executeCommand(command, args);
+        } catch (error) {
+            console.error(error); //eslint-disable-line no-console
+        }
     };
 }

--- a/webapp/src/components/sidebar_right/confirmation_modal.jsx
+++ b/webapp/src/components/sidebar_right/confirmation_modal.jsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import {Button, Modal} from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import './deletion_unlock_confirmation_modal.scss';
+import './confirmation_modal.scss';
 
-function DeletionUnlockConfirmationModal({visible, onConfirm, onCancel}) {
+function ConfirmationModal({title, bodyText, visible, onConfirm, onCancel}) {
     return (
         <Modal
+            title={title}
+            bodyText={bodyText}
             show={visible}
             onHide={onCancel}
             onCancel={onCancel}
-            className={'CloudPluginUnlockDeletionConfirmationModal'}
+            className={'CloudPluginConfirmationModal'}
         >
             <Modal.Header closeButton={false}>
-                <Modal.Title>Remove deletion lock?</Modal.Title>
+                <Modal.Title>{title}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                <p>
-                    Are you sure you want to remove the deletion lock? Doing so will add this installation back into the clean up pool, meaning it can be deleted.
-                </p>
+                <p>{bodyText}</p>
             </Modal.Body>
             <Modal.Footer>
                 <Button
@@ -32,17 +32,19 @@ function DeletionUnlockConfirmationModal({visible, onConfirm, onCancel}) {
                     bsStyle='danger'
                     onClick={onConfirm}
                 >
-                    Remove Lock
+                    Confirm
                 </Button>
             </Modal.Footer>
         </Modal>
     );
 }
 
-DeletionUnlockConfirmationModal.propTypes = {
+ConfirmationModal.propTypes = {
+    title: PropTypes.string.isRequired,
+    bodyText: PropTypes.string.isRequired,
     visible: PropTypes.bool.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
 };
 
-export default DeletionUnlockConfirmationModal;
+export default ConfirmationModal;

--- a/webapp/src/components/sidebar_right/confirmation_modal.scss
+++ b/webapp/src/components/sidebar_right/confirmation_modal.scss
@@ -1,4 +1,4 @@
-.CloudPluginUnlockDeletionConfirmationModal {
+.CloudPluginConfirmationModal {
     .modal-content {
         border: none;
         border-radius: 8px;

--- a/webapp/src/components/sidebar_right/confirmation_modal.test.jsx
+++ b/webapp/src/components/sidebar_right/confirmation_modal.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 
-import DeletionUnlockConfirmationModal from './deletion_unlock_confirmation_modal';
+import ConfirmationModal from './confirmation_modal';
 
 describe('DeletionUnlockConfirmationModal', () => {
     const mockOnConfirm = jest.fn();
@@ -12,45 +12,50 @@ describe('DeletionUnlockConfirmationModal', () => {
     });
 
     it('renders the modal with the correct title and message', () => {
+        const title = 'Title Message';
+        const bodyText = 'Scary message about what could go wrong';
+
         const props = {
+            title,
+            bodyText,
             visible: true,
             onConfirm: mockOnConfirm,
             onCancel: mockOnCancel,
         };
 
-        render(<DeletionUnlockConfirmationModal {...props}/>);
+        render(<ConfirmationModal {...props}/>);
 
-        expect(screen.getByText('Remove deletion lock?')).toBeInTheDocument();
-        expect(
-            screen.getByText(
-                'Are you sure you want to remove the deletion lock? Doing so will add this installation back into the clean up pool, meaning it can be deleted.',
-            ),
-        ).toBeInTheDocument();
+        expect(screen.getByText(title)).toBeInTheDocument();
+        expect(screen.getByText(bodyText)).toBeInTheDocument();
     });
 
-    it('calls the onConfirm function when "Remove Lock" button is clicked', () => {
+    it('calls the onConfirm function when "Confirm" button is clicked', () => {
         const props = {
+            title: 'title',
+            bodyText: 'text',
             visible: true,
             onConfirm: mockOnConfirm,
             onCancel: mockOnCancel,
         };
 
-        render(<DeletionUnlockConfirmationModal {...props}/>);
+        render(<ConfirmationModal {...props}/>);
 
-        const removeLockButton = screen.getByText('Remove Lock');
-        fireEvent.click(removeLockButton);
+        const confirmButton = screen.getByText('Confirm');
+        fireEvent.click(confirmButton);
 
         expect(mockOnConfirm).toHaveBeenCalledTimes(1);
     });
 
     it('calls the onCancel function when "Cancel" button is clicked', () => {
         const props = {
+            title: 'title',
+            bodyText: 'text',
             visible: true,
             onConfirm: mockOnConfirm,
             onCancel: mockOnCancel,
         };
 
-        render(<DeletionUnlockConfirmationModal {...props}/>);
+        render(<ConfirmationModal {...props}/>);
 
         const cancelButton = screen.getByText('Cancel');
         fireEvent.click(cancelButton);
@@ -59,19 +64,20 @@ describe('DeletionUnlockConfirmationModal', () => {
     });
 
     it('does not render the modal when visible is false', () => {
+        const title = 'Title Message';
+        const bodyText = 'Scary message about what could go wrong';
+
         const props = {
+            title,
+            bodyText,
             visible: false,
             onConfirm: mockOnConfirm,
             onCancel: mockOnCancel,
         };
 
-        render(<DeletionUnlockConfirmationModal {...props}/>);
+        render(<ConfirmationModal {...props}/>);
 
-        expect(screen.queryByText('Remove deletion lock?')).toBeNull();
-        expect(
-            screen.queryByText(
-                'Are you sure you want to remove the deletion lock? Doing so will add this installation back into the clean up pool, meaning it can be deleted.',
-            ),
-        ).toBeNull();
+        expect(screen.queryByText(title)).toBeNull();
+        expect(screen.queryByText(bodyText)).toBeNull();
     });
 });

--- a/webapp/src/components/sidebar_right/index.js
+++ b/webapp/src/components/sidebar_right/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 
-import {telemetry, setRhsVisible, getCloudUserData, getSharedInstalls, deletionLockInstallation, deletionUnlockInstallation, getPluginConfiguration} from '../../actions';
+import {telemetry, setRhsVisible, getCloudUserData, getSharedInstalls, restartInstallation, deletionLockInstallation, deletionUnlockInstallation, getPluginConfiguration} from '../../actions';
 
 import {installsForUser, sharedInstalls, serverError, pluginConfiguration} from '../../selectors';
 
@@ -29,6 +29,7 @@ function mapDispatchToProps(dispatch) {
             getCloudUserData,
             getSharedInstalls,
             setVisible: setRhsVisible,
+            restartInstallation,
             deletionLockInstallation,
             deletionUnlockInstallation,
             getPluginConfiguration,

--- a/webapp/src/components/sidebar_right/sidebar_right.test.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.test.jsx
@@ -60,6 +60,7 @@ describe('SidebarRight', () => {
             telemetry: jest.fn(),
             getCloudUserData: jest.fn(),
             getSharedInstalls: jest.fn(),
+            restartInstallation: jest.fn(),
             deletionLockInstallation: jest.fn(),
             deletionUnlockInstallation: jest.fn(),
             getPluginConfiguration: jest.fn(),
@@ -118,6 +119,18 @@ describe('SidebarRight', () => {
         expect(props.actions.getPluginConfiguration).toHaveBeenCalled();
     });
 
+    it('calls the restartInstallation action when the restart button is clicked', () => {
+        render(<SidebarRight {...props}/>);
+
+        const restartButton = screen.getByTestId('restart-1');
+        fireEvent.click(restartButton);
+
+        const confirmButton = screen.getByText('Confirm');
+        fireEvent.click(confirmButton);
+
+        expect(props.actions.restartInstallation).toHaveBeenCalledWith('Test Installation 1');
+    });
+
     it('calls the deletionLockInstallation action when the lock deletion button is clicked', () => {
         const newProps = props;
 
@@ -137,7 +150,7 @@ describe('SidebarRight', () => {
         const unlockButton = screen.getByText('Unlock Deletion');
         fireEvent.click(unlockButton);
 
-        const confirmButton = screen.getByText('Remove Lock');
+        const confirmButton = screen.getByText('Confirm');
         fireEvent.click(confirmButton);
 
         expect(props.actions.deletionUnlockInstallation).toHaveBeenCalledWith('2');


### PR DESCRIPTION
The button provides an easy way to restart Mattermost server instances. A confirmation modal is presented before the restart is kicked off.

Fixes https://mattermost.atlassian.net/browse/CLD-6789

```release-note
Add installation restart button to UI
```
