### PR TITLE
[CLD-6815] Fix console errors when first loading user and shared installs

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -97,8 +97,7 @@ export function getCloudUserData(userID) {
         }
 
         const data = await Client.getUserInstalls(userID);
-
-        if (data.error) {
+        if (data && data.error) {
             if (data.error.status === 404) {
                 dispatch({
                     type: RECEIVED_USER_INSTALLS,
@@ -129,7 +128,7 @@ export function getSharedInstalls() {
     return async (dispatch, getState) => {
         const data = await Client.getSharedInstalls();
 
-        if (data.error) {
+        if (data && data.error) {
             dispatch(setServerError(`Status: ${data.error.status}, Message: ${data.error.message}`));
             return data;
         }


### PR DESCRIPTION
#### Summary
When the user doesn't have any installs (or there are no shared installs) the server returns `null` - this PR asserts that the response is non-null before attempting to access error data.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6815

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
