### PR TITLE
[CLD-6962] Remove bottom border on confirmation modal

### DIFF
--- a/webapp/src/components/sidebar_right/confirmation_modal.scss
+++ b/webapp/src/components/sidebar_right/confirmation_modal.scss
@@ -4,7 +4,7 @@
         border-radius: 8px;
         .modal-header {
             border: none;
-            border-bottom: 1px solid #e5e5e5;
+            border-radius: 8px;
             background: var(--center-channel-bg);
             .modal-title {
                 color: var(--center-channel-color);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Removes the bottom border on the modal header. Now looks like:

![image](https://github.com/mattermost/mattermost-plugin-cloud/assets/12176405/484375e1-1071-454e-99fc-b9733a26f244)


#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6962
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
