### PR TITLE
Don't build server for Windows environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ ifneq ($(HAS_SERVER),)
 	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -o dist/plugin-linux-amd64;
 	cd server && env GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -o dist/plugin-darwin-amd64;
 	cd server && env GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -o dist/plugin-darwin-arm64;
-	cd server && env GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -o dist/plugin-windows-amd64.exe;
 endif
 
 ## Ensures NPM dependencies are installed without having to run this all the time.

--- a/plugin.json
+++ b/plugin.json
@@ -8,8 +8,7 @@
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",
             "darwin-amd64": "server/dist/plugin-darwin-amd64",
-            "darwin-arm64": "server/dist/plugin-darwin-arm64",
-            "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+            "darwin-arm64": "server/dist/plugin-darwin-arm64"
         }
     },
     "webapp": {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.cloud",
     "name": "Mattermost Private Cloud",
     "description": "This plugin allows spinning up and down Mattermost installations using Mattermost Private Cloud.",
-    "version": "0.1.34",
+    "version": "0.1.35",
     "min_server_version": "8.1.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "com.mattermost.cloud",
-	Version: "0.1.34",
+	Version: "0.1.35",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'com.mattermost.cloud';
-export const version = '0.1.34';
+export const version = '0.1.35';


### PR DESCRIPTION
#### Summary
Prior to this change the bundle size of this plugin's tar.gz file is over 111MB, which exceeds Mattermost Server's file size limit (for uploading) of 104MB. The gzip is packaging binaries for Linux amd64, Darwin amd64, Darwin arm64, and Windows.

We don't run this in a Windows environment. This PR drops the windows binary build from the dist step, which reduces the bundle size to 83.5MB, which will not require a change to the server's config to upload. 

#### Ticket Link
I keep having to change the setting and it bothered me

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
