### PR TITLE
Support --shared-installation for /cloud restart

### DIFF
--- a/server/command_restart.go
+++ b/server/command_restart.go
@@ -6,23 +6,42 @@ import (
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
+	flag "github.com/spf13/pflag"
 )
+
+func getRestartFlagSet() *flag.FlagSet {
+	restartFlagSet := flag.NewFlagSet("restart", flag.ContinueOnError)
+	restartFlagSet.Bool("shared-installation", false, "Set this to true when attempting to restart a shared installation")
+
+	return restartFlagSet
+}
 
 func (p *Plugin) runRestartCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
 	if len(args) == 0 || len(args[0]) == 0 {
 		return nil, true, errors.New("must provide an installation name")
 	}
 
+	restartFlagSet := getRestartFlagSet()
+	err := restartFlagSet.Parse(args)
+	if err != nil {
+		return nil, true, err
+	}
+
+	includeShared, err := restartFlagSet.GetBool("shared-installation")
+	if err != nil {
+		return nil, false, err
+	}
+
 	name := standardizeName(args[0])
 
-	installs, _, err := p.getInstallations()
+	installs, err := p.getUpdatableInstallationsForUser(extra.UserId, includeShared)
 	if err != nil {
 		return nil, false, err
 	}
 
 	var installToRestart *Installation
 	for _, install := range installs {
-		if install.OwnerID == extra.UserId && standardizeName(install.Name) == name {
+		if standardizeName(install.Name) == name {
 			installToRestart = install
 			break
 		}

--- a/server/command_update.go
+++ b/server/command_update.go
@@ -113,32 +113,16 @@ func (p *Plugin) runUpdateCommand(args []string, extra *model.CommandArgs) (*mod
 	}
 	var installToUpdate *Installation
 
-	if shared {
-		installs, sharedErr := p.getSharedInstallations()
-		if sharedErr != nil {
-			return nil, false, sharedErr
-		}
+	installs, err := p.getUpdatableInstallationsForUser(extra.UserId, shared)
+	if err != nil {
+		return nil, false, err
+	}
 
-		for _, install := range installs {
-			if install.Name == name {
-				if !install.AllowSharedUpdates {
-					return nil, true, errors.Errorf("installation %s is shared, but the owner has not allowed for others to update it", name)
-				}
-				installToUpdate = install
-				break
-			}
-		}
-	} else {
-		installs, _, installsErr := p.getInstallations()
-		if installsErr != nil {
-			return nil, false, installsErr
-		}
-
-		for _, install := range installs {
-			if install.OwnerID == extra.UserId && install.Name == name {
-				installToUpdate = install
-				break
-			}
+	// Find the installation by name
+	for _, install := range installs {
+		if install.Name == name {
+			installToUpdate = install
+			break
 		}
 	}
 

--- a/server/command_update_test.go
+++ b/server/command_update_test.go
@@ -299,7 +299,7 @@ func TestUpdateCommand(t *testing.T) {
 
 			resp, isUserError, err := plugin.runUpdateCommand([]string{"gabesinstall", "--env", "ENV1=test", "--shared-installation"}, &model.CommandArgs{UserId: "gabeid"})
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "installation gabesinstall is shared, but the owner has not allowed for others to update it")
+			assert.Contains(t, err.Error(), "no installation with the name gabesinstall found")
 			assert.True(t, isUserError)
 			assert.Nil(t, resp)
 		})

--- a/server/installation.go
+++ b/server/installation.go
@@ -232,6 +232,24 @@ func (p *Plugin) getInstallationsForUser(userID string) ([]*Installation, error)
 	return installsForUser, nil
 }
 
+// getUpdatableInstallationsForUser returns installations the given user can update. Unless
+// includeShared is set, this is equivalent to calling getInstallationsForUser.
+func (p *Plugin) getUpdatableInstallationsForUser(userID string, includeShared bool) ([]*Installation, error) {
+	installs, _, err := p.getInstallations()
+	if err != nil {
+		return nil, err
+	}
+
+	updatableInstallsForUser := []*Installation{}
+	for _, install := range installs {
+		if install.OwnerID == userID || (includeShared && install.Shared && install.AllowSharedUpdates) {
+			updatableInstallsForUser = append(updatableInstallsForUser, install)
+		}
+	}
+
+	return updatableInstallsForUser, nil
+}
+
 func (p *Plugin) getUpdatedSharedInstallations() ([]*Installation, error) {
 	sharedInstalls, err := p.getSharedInstallations()
 	if err != nil {


### PR DESCRIPTION
#### Summary
Support `--shared-installation` for `/cloud restart`, allowing additional administration of these instances.

Note that I realize I can achieve a restart today by setting a bogus environment variable too, but this is more of a dry run to start extending the shared functionality for other use cases like `mmctl`.

#### Ticket Link
None.

#### Release Note
```release-note
Support --shared-installation for /cloud restart
```
