### PR TITLE
[CLD-7377] Remove specific configs for test licenses

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -80,18 +80,6 @@
                 "help_text": "The contents of a Professional license."
             },
             {
-                "key": "TestEnterpriseLicense",
-                "display_name": "Mattermost Enterprise License used for servers built for internal testing",
-                "type": "longtext",
-                "help_text": "The contents of an Enterpise license."
-            },
-            {
-                "key": "TestProfessionalLicense",
-                "display_name": "Mattermost Professional License used for servers built for internal testing",
-                "type": "longtext",
-                "help_text": "The contents of a Professional license."
-            },
-            {
                 "key": "GroupID",
                 "display_name": "Group ID",
                 "type": "text",

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -228,7 +228,7 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		Database:    install.Database,
 		Filestore:   install.Filestore,
 		PriorityEnv: install.PriorityEnv,
-		License:     p.getLicenseValue(install.License, install.Image),
+		License:     p.getLicenseValue(install.License),
 		Size:        install.Size,
 		Version:     install.Version,
 		Image:       install.Image,

--- a/server/command_update.go
+++ b/server/command_update.go
@@ -158,14 +158,9 @@ func (p *Plugin) runUpdateCommand(args []string, extra *model.CommandArgs) (*mod
 		request.Version = &digest
 	}
 
-	// Obtain the new image value if there is one to properly apply a license.
-	image := installToUpdate.Image
-	if request.Image != nil {
-		image = *request.Image
-	}
 	if request.License != nil {
 		// Translate the license option.
-		licenseValue := p.getLicenseValue(*request.License, image)
+		licenseValue := p.getLicenseValue(*request.License)
 		request.License = &licenseValue
 	}
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -76,12 +76,10 @@ type configuration struct {
 	ProvisioningServerWebhookSecret           string
 
 	// License
-	E10License              string
-	E20License              string
-	EnterpriseLicense       string
-	ProfessionalLicense     string
-	TestEnterpriseLicense   string
-	TestProfessionalLicense string
+	E10License          string
+	E20License          string
+	EnterpriseLicense   string
+	ProfessionalLicense string
 
 	// Groups
 	GroupID string
@@ -222,23 +220,13 @@ func (p *Plugin) setCloudClient() {
 	p.cloudClient = cloud.NewClientWithHeaders(configuration.ProvisioningServerURL, authHeaders)
 }
 
-func (p *Plugin) getLicenseValue(licenseOption, image string) string {
+func (p *Plugin) getLicenseValue(licenseOption string) string {
 	config := p.getConfiguration()
 
 	switch licenseOption {
 	case licenseOptionEnterprise:
-		for _, ti := range dockerRepoTestImages {
-			if ti == image {
-				return config.TestEnterpriseLicense
-			}
-		}
 		return config.EnterpriseLicense
 	case licenseOptionProfessional:
-		for _, ti := range dockerRepoTestImages {
-			if ti == image {
-				return config.TestProfessionalLicense
-			}
-		}
 		return config.ProfessionalLicense
 	case licenseOptionE20:
 		return config.E20License

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -96,13 +96,13 @@ func TestGetLicenseValue(t *testing.T) {
 
 	t.Run("enterprise", func(t *testing.T) {
 		t.Run("license", func(t *testing.T) {
-			assert.Equal(t, "testenterpriselicense", plugin.getLicenseValue(licenseOptionEnterprise))
+			assert.Equal(t, "enterpriselicense", plugin.getLicenseValue(licenseOptionEnterprise))
 		})
 	})
 
 	t.Run("professional", func(t *testing.T) {
 		t.Run("license", func(t *testing.T) {
-			assert.Equal(t, "testprofessionallicense", plugin.getLicenseValue(licenseOptionProfessional))
+			assert.Equal(t, "professionallicense", plugin.getLicenseValue(licenseOptionProfessional))
 		})
 	})
 

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -75,48 +75,38 @@ func TestConfigurationIsValid(t *testing.T) {
 func TestGetLicenseValue(t *testing.T) {
 	plugin := Plugin{
 		configuration: &configuration{
-			E10License:              "e10license",
-			E20License:              "e20license",
-			EnterpriseLicense:       "enterpriselicense",
-			ProfessionalLicense:     "professionallicense",
-			TestEnterpriseLicense:   "testenterpriselicense",
-			TestProfessionalLicense: "testprofessionallicense",
+			E10License:          "e10license",
+			E20License:          "e20license",
+			EnterpriseLicense:   "enterpriselicense",
+			ProfessionalLicense: "professionallicense",
 		},
 	}
 
 	t.Run("e20", func(t *testing.T) {
-		t.Run("no test image", func(t *testing.T) {
-			assert.Equal(t, "e20license", plugin.getLicenseValue(licenseOptionE20, imageEE))
-		})
-		t.Run("test image", func(t *testing.T) {
-			assert.Equal(t, "e20license", plugin.getLicenseValue(licenseOptionE20, imageEETest))
+		t.Run("license", func(t *testing.T) {
+			assert.Equal(t, "e20license", plugin.getLicenseValue(licenseOptionE20))
 		})
 	})
 
 	t.Run("e10", func(t *testing.T) {
-		t.Run("no test image", func(t *testing.T) {
-			assert.Equal(t, "e10license", plugin.getLicenseValue(licenseOptionE10, imageEE))
-		})
-		t.Run("test image", func(t *testing.T) {
-			assert.Equal(t, "e10license", plugin.getLicenseValue(licenseOptionE10, imageEETest))
+		t.Run("license", func(t *testing.T) {
+			assert.Equal(t, "e10license", plugin.getLicenseValue(licenseOptionE10))
 		})
 	})
 
 	t.Run("enterprise", func(t *testing.T) {
-		t.Run("no test image", func(t *testing.T) {
-			assert.Equal(t, "enterpriselicense", plugin.getLicenseValue(licenseOptionEnterprise, imageEE))
-		})
-		t.Run("test image", func(t *testing.T) {
-			assert.Equal(t, "testenterpriselicense", plugin.getLicenseValue(licenseOptionEnterprise, imageEETest))
+		t.Run("license", func(t *testing.T) {
+			assert.Equal(t, "testenterpriselicense", plugin.getLicenseValue(licenseOptionEnterprise))
 		})
 	})
 
 	t.Run("professional", func(t *testing.T) {
-		t.Run("no test image", func(t *testing.T) {
-			assert.Equal(t, "professionallicense", plugin.getLicenseValue(licenseOptionProfessional, imageEE))
+		t.Run("license", func(t *testing.T) {
+			assert.Equal(t, "testprofessionallicense", plugin.getLicenseValue(licenseOptionProfessional))
 		})
-		t.Run("test image", func(t *testing.T) {
-			assert.Equal(t, "testprofessionallicense", plugin.getLicenseValue(licenseOptionProfessional, imageEETest))
-		})
+	})
+
+	t.Run("no matching", func(t *testing.T) {
+		assert.Equal(t, "", plugin.getLicenseValue("nope"))
 	})
 }


### PR DESCRIPTION
#### Summary
Having support for both test and prod licenses has caused lots of confusion. All cloud test servers created through this plugin are put into a group with the `MM_SERVICEENVIRONMENT` variable set to `test` - if you requested mattermost/mattermost-enterprise-edition, it would apply a production license, and then break. This PR makes it so that the test license is always used in a cloud plugin workspace. Those who want to test a production license for whatever reason can do so by updating the MM_SERVICEENVIRONMENT of their workspace via priority ENV, and applying a production license.

Note: We will need to update the configurations for the ProfessionalLicense, EnterpriseLicense, E20License, and E10License to ensure they all contain test environment licenses. Once this update has completed, creation will "just work" going forward, with the flexibility to use production if desired. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7377

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Removed support for env-specific licenses to avoid future confusion.
```
