### PR TITLE
Add autocompletion to the slash command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -82,9 +82,160 @@ func getCommand() *model.Command {
 		Trigger:          "cloud",
 		DisplayName:      "Mattermost Private Cloud",
 		Description:      "This command allows spinning up and down Mattermost installations using Mattermost Private Cloud.",
-		AutoComplete:     false,
-		AutoCompleteDesc: "Available commands: create, list, update, mmcli, mmctl, delete",
+		AutoComplete:     true,
+		AutoCompleteDesc: "Available commands: create, list, update, mmcli, mmctl, delete, share, unshare, restart, hibernate, wake-up, info, import",
 		AutoCompleteHint: "[command]",
+		AutocompleteData: &model.AutocompleteData{
+			Trigger: "cloud",
+			RoleID: "system_user",
+			SubCommands: []*model.AutocompleteData{
+				{
+					Trigger: "create",
+					HelpText: "Creates a Mattermost installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation",
+							Required: true,
+						},
+					},
+					Flags: []*model.AutocompleteFlag{
+						{
+							Name: "license",
+							Type: model.AutocompleteFlagTypeString,
+							HelpText: "License type (e.g. 'e10', 'enterprise')",
+						},
+						{
+							Name: "test-data",
+							Type: model.AutocompleteFlagTypeBoolean,
+							HelpText: "Include test data in installation",
+						},
+					},
+				},
+				{
+					Trigger: "list",
+					HelpText: "Lists your Mattermost installations",
+					Flags: []*model.AutocompleteFlag{
+						{
+							Name: "shared-installations",
+							Type: model.AutocompleteFlagTypeBoolean,
+							HelpText: "Lists shared installations instead of personal ones",
+						},
+					},
+				},
+				{
+					Trigger: "update",
+					HelpText: "Update a Mattermost installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation to update",
+							Required: true,
+						},
+					},
+					Flags: []*model.AutocompleteFlag{
+						{
+							Name: "version",
+							Type: model.AutocompleteFlagTypeString,
+							HelpText: "Mattermost version to run",
+						},
+						{
+							Name: "license",
+							Type: model.AutocompleteFlagTypeString,
+							HelpText: "Enterprise license to use",
+						},
+					},
+				},
+				{
+					Trigger: "share",
+					HelpText: "Share a Mattermost installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation to share",
+							Required: true,
+						},
+					},
+					Flags: []*model.AutocompleteFlag{
+						{
+							Name: "allow-updates",
+							Type: model.AutocompleteFlagTypeBoolean,
+							HelpText: "Allow other users to update the installation",
+						},
+					},
+				},
+				{
+					Trigger: "unshare",
+					HelpText: "Remove sharing from an installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation to unshare",
+							Required: true,
+						},
+					},
+				},
+				{
+					Trigger: "restart",
+					HelpText: "Restart a Mattermost installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation to restart",
+							Required: true,
+						},
+					},
+				},
+				{
+					Trigger: "hibernate",
+					HelpText: "Hibernate a Mattermost installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation to hibernate",
+							Required: true,
+						},
+					},
+				},
+				{
+					Trigger: "wake-up",
+					HelpText: "Wake up a hibernated installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation to wake up",
+							Required: true,
+						},
+					},
+				},
+				{
+					Trigger: "delete",
+					HelpText: "Delete a Mattermost installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "name",
+							HelpText: "Name of the installation to delete",
+							Required: true,
+						},
+					},
+				},
+				{
+					Trigger: "info",
+					HelpText: "Show cloud plugin information",
+				},
+				{
+					Trigger: "import",
+					HelpText: "Import an existing installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Name: "DNS",
+							HelpText: "DNS value of the installation to import",
+							Required: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/server/command.go
+++ b/server/command.go
@@ -98,28 +98,26 @@ func getCommand() *model.Command {
 							HelpText: "Name of the installation",
 							Required: true,
 						},
-					},
-					Flags: []*model.AutocompleteFlag{
 						{
 							Name: "license",
-							Type: model.AutocompleteFlagTypeString,
 							HelpText: "License type (e.g. 'e10', 'enterprise')",
+							Optional: true,
 						},
 						{
 							Name: "test-data",
-							Type: model.AutocompleteFlagTypeBoolean,
 							HelpText: "Include test data in installation",
+							Optional: true,
 						},
 					},
 				},
 				{
 					Trigger: "list",
 					HelpText: "Lists your Mattermost installations",
-					Flags: []*model.AutocompleteFlag{
+					Arguments: []*model.AutocompleteArg{
 						{
 							Name: "shared-installations",
-							Type: model.AutocompleteFlagTypeBoolean,
 							HelpText: "Lists shared installations instead of personal ones",
+							Optional: true,
 						},
 					},
 				},
@@ -132,17 +130,15 @@ func getCommand() *model.Command {
 							HelpText: "Name of the installation to update",
 							Required: true,
 						},
-					},
-					Flags: []*model.AutocompleteFlag{
 						{
 							Name: "version",
-							Type: model.AutocompleteFlagTypeString,
 							HelpText: "Mattermost version to run",
+							Optional: true,
 						},
 						{
 							Name: "license",
-							Type: model.AutocompleteFlagTypeString,
 							HelpText: "Enterprise license to use",
+							Optional: true,
 						},
 					},
 				},
@@ -155,12 +151,10 @@ func getCommand() *model.Command {
 							HelpText: "Name of the installation to share",
 							Required: true,
 						},
-					},
-					Flags: []*model.AutocompleteFlag{
 						{
 							Name: "allow-updates",
-							Type: model.AutocompleteFlagTypeBoolean,
 							HelpText: "Allow other users to update the installation",
+							Optional: true,
 						},
 					},
 				},

--- a/server/command.go
+++ b/server/command.go
@@ -106,7 +106,7 @@ func getCommand() *model.Command {
 						{
 							Name: "test-data",
 							HelpText: "Include test data in installation",
-							Optional: true,
+							Required: false,
 						},
 					},
 				},

--- a/server/command.go
+++ b/server/command.go
@@ -101,7 +101,7 @@ func getCommand() *model.Command {
 						{
 							Name: "license",
 							HelpText: "License type (e.g. 'e10', 'enterprise')",
-							Optional: true,
+							Required: false,
 						},
 						{
 							Name: "test-data",
@@ -117,7 +117,7 @@ func getCommand() *model.Command {
 						{
 							Name: "shared-installations",
 							HelpText: "Lists shared installations instead of personal ones",
-							Optional: true,
+							Required: false,
 						},
 					},
 				},
@@ -133,12 +133,12 @@ func getCommand() *model.Command {
 						{
 							Name: "version",
 							HelpText: "Mattermost version to run",
-							Optional: true,
+							Required: false,
 						},
 						{
 							Name: "license",
 							HelpText: "Enterprise license to use",
-							Optional: true,
+							Required: false,
 						},
 					},
 				},
@@ -154,7 +154,7 @@ func getCommand() *model.Command {
 						{
 							Name: "allow-updates",
 							HelpText: "Allow other users to update the installation",
-							Optional: true,
+							Required: false,
 						},
 					},
 				},


### PR DESCRIPTION
#### Summary
This is a PR that adds the ability to have autocompletion for cloud slash commands.

This is made with AI using aider and I was unable to test it properly because I don't have the configuration ready.

```release-note
Add slash command autocompletion
```