### PR TITLE
Add debug packet functionality

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -278,6 +278,67 @@ func (p *Plugin) getCommand() *model.Command {
 					},
 				},
 				{
+					Trigger:  "mmcli",
+					HelpText: "Runs Mattermost CLI commands on an installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Type: model.AutocompleteArgTypeText,
+							Data: &model.AutocompleteTextArg{
+								Hint:    "name",
+								Pattern: "^[a-zA-Z0-9-]+$",
+							},
+							HelpText: "Name of the installation to run CLI commands on",
+							Required: true,
+						},
+						{
+							Type: model.AutocompleteArgTypeText,
+							Data: &model.AutocompleteTextArg{
+								Hint: "mattermost-subcommand",
+							},
+							HelpText: "The Mattermost CLI subcommand to run",
+							Required: true,
+						},
+					},
+				},
+				{
+					Trigger:  "mmctl",
+					HelpText: "Runs mmctl commands on an installation",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Type: model.AutocompleteArgTypeText,
+							Data: &model.AutocompleteTextArg{
+								Hint:    "name",
+								Pattern: "^[a-zA-Z0-9-]+$",
+							},
+							HelpText: "Name of the installation to run mmctl commands on",
+							Required: true,
+						},
+						{
+							Type: model.AutocompleteArgTypeText,
+							Data: &model.AutocompleteTextArg{
+								Hint: "mmctl-subcommand",
+							},
+							HelpText: "The mmctl subcommand to run",
+							Required: true,
+						},
+					},
+				},
+				{
+					Trigger:  "debug-packet",
+					HelpText: "Get a debug packet containing performance data",
+					Arguments: []*model.AutocompleteArg{
+						{
+							Type: model.AutocompleteArgTypeText,
+							Data: &model.AutocompleteTextArg{
+								Hint:    "name",
+								Pattern: "^[a-zA-Z0-9-]+$",
+							},
+							HelpText: "Name of the installation to get the packet from",
+							Required: true,
+						},
+					},
+				},
+				{
 					Trigger:  "restart",
 					HelpText: "Restart a Mattermost installation",
 					Arguments: []*model.AutocompleteArg{
@@ -355,52 +416,6 @@ func (p *Plugin) getCommand() *model.Command {
 						},
 					},
 				},
-				{
-					Trigger:  "mmcli",
-					HelpText: "Runs Mattermost CLI commands on an installation",
-					Arguments: []*model.AutocompleteArg{
-						{
-							Type: model.AutocompleteArgTypeText,
-							Data: &model.AutocompleteTextArg{
-								Hint:    "name",
-								Pattern: "^[a-zA-Z0-9-]+$",
-							},
-							HelpText: "Name of the installation to run CLI commands on",
-							Required: true,
-						},
-						{
-							Type: model.AutocompleteArgTypeText,
-							Data: &model.AutocompleteTextArg{
-								Hint: "mattermost-subcommand",
-							},
-							HelpText: "The Mattermost CLI subcommand to run",
-							Required: true,
-						},
-					},
-				},
-				{
-					Trigger:  "mmctl",
-					HelpText: "Runs mmctl commands on an installation",
-					Arguments: []*model.AutocompleteArg{
-						{
-							Type: model.AutocompleteArgTypeText,
-							Data: &model.AutocompleteTextArg{
-								Hint:    "name",
-								Pattern: "^[a-zA-Z0-9-]+$",
-							},
-							HelpText: "Name of the installation to run mmctl commands on",
-							Required: true,
-						},
-						{
-							Type: model.AutocompleteArgTypeText,
-							Data: &model.AutocompleteTextArg{
-								Hint: "mmctl-subcommand",
-							},
-							HelpText: "The mmctl subcommand to run",
-							Required: true,
-						},
-					},
-				},
 			},
 		},
 	}
@@ -444,6 +459,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		handler = p.runUpgradeHelperCommand
 	case "update":
 		handler = p.runUpdateCommand
+	case "debug-packet":
+		handler = p.runGetDebugPacketCommand
 	case "restart":
 		handler = p.runRestartCommand
 	case "hibernate":

--- a/server/command.go
+++ b/server/command.go
@@ -429,7 +429,7 @@ func (p *Plugin) getCommand() *model.Command {
 						{
 							Type: model.AutocompleteArgTypeText,
 							Data: &model.AutocompleteTextArg{
-								Hint:    "name",
+								Hint:    "[name]",
 								Pattern: "^[a-zA-Z0-9-]+$",
 							},
 							HelpText: "Name of the installation to get the packet from",

--- a/server/command_debug_packet.go
+++ b/server/command_debug_packet.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/pkg/errors"
+)
+
+func (p *Plugin) runGetDebugPacketCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	if len(args) == 0 {
+		return nil, true, errors.New("must provide an installation name")
+	}
+
+	name := standardizeName(args[0])
+	if name == "" {
+		return nil, true, errors.New("must provide an installation name")
+	}
+
+	installsForUser, err := p.getInstallationsForUser(extra.UserId)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var installToExec *Installation
+	for _, install := range installsForUser {
+		if install.OwnerID == extra.UserId && install.Name == name {
+			installToExec = install
+			break
+		}
+	}
+
+	if installToExec == nil {
+		return nil, true, fmt.Errorf("no installation with the name %s found", name)
+	}
+
+	p.API.SendEphemeralPost(extra.UserId, &model.Post{
+		UserId:    p.BotUserID,
+		ChannelId: extra.ChannelId,
+		Message:   fmt.Sprintf("Gathering debug data for `%s` now. Please wait as this may take a while.", installToExec.Name),
+	})
+
+	err = p.execGetDebugPacket(installToExec.ID, extra.UserId, name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	resp := "Debug packet generated. Check your direct messages from the cloud bot."
+
+	return getCommandResponse(model.CommandResponseTypeEphemeral, resp, extra), false, nil
+}
+
+func (p *Plugin) execGetDebugPacket(installationID, userID, installationName string) error {
+	clusterInstallations, err := p.cloudClient.GetClusterInstallations(&cloud.GetClusterInstallationsRequest{
+		InstallationID: installationID,
+		Paging:         cloud.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to get cluster installations")
+	}
+
+	if len(clusterInstallations) == 0 {
+		return fmt.Errorf("no cluster installations found for installation %s", installationID)
+	}
+
+	fileBytes, err := p.cloudClient.ExecClusterInstallationPPROF(clusterInstallations[0].ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to gather debug packet data")
+	}
+	if fileBytes == nil {
+		return errors.Wrap(err, "no debug data returned")
+	}
+
+	botDMChannel, appErr := p.API.GetDirectChannel(userID, p.BotUserID)
+	if appErr != nil {
+		return err
+	}
+	if botDMChannel == nil {
+		return fmt.Errorf("could not get direct channel for bot and user_id=%s", userID)
+	}
+
+	filename := fmt.Sprintf("%s.%d.debug.zip", installationName, time.Now().UnixMilli())
+	fileInfo, appErr := p.API.UploadFile(fileBytes, botDMChannel.Id, filename)
+	if appErr != nil {
+		return errors.Wrap(err, "unable to upload debug file")
+	}
+
+	_, err = p.API.CreatePost(&model.Post{
+		UserId:    p.BotUserID,
+		ChannelId: botDMChannel.Id,
+		Message:   fmt.Sprintf("Here is a debug packet for installation %s", installationName),
+		FileIds:   []string{fileInfo.Id},
+	})
+
+	return nil
+}

--- a/server/command_debug_packet_test.go
+++ b/server/command_debug_packet_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDebugPacketCommand(t *testing.T) {
+	mockedCloudClient := &MockClient{}
+	plugin := Plugin{cloudClient: mockedCloudClient}
+
+	api := &plugintest.API{}
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.Channel{}, nil)
+	api.On("UploadFile", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.FileInfo{}, nil)
+	api.On("CreatePost", mock.Anything).Return(&model.Post{}, nil)
+	api.On("SendEphemeralPost", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	plugin.SetAPI(api)
+
+	ci1 := &cloud.ClusterInstallation{
+		ID: cloud.NewID(),
+	}
+	mockedCloudClient.mockedCloudClusterInstallations = []*cloud.ClusterInstallation{ci1}
+
+	t.Run("run command successfully", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runGetDebugPacketCommand([]string{"gabesinstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Debug packet generated")
+	})
+
+	t.Run("run command successfully with caps in name to show name is case insensitive", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+
+		resp, isUserError, err := plugin.runGetDebugPacketCommand([]string{"GabesInstall"}, &model.CommandArgs{UserId: "gabeid"})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Debug packet generated")
+	})
+
+	t.Run("no name provided", func(t *testing.T) {
+		resp, isUserError, err := plugin.runGetDebugPacketCommand([]string{}, &model.CommandArgs{UserId: "gabeid2"})
+		require.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "must provide an installation name"))
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+
+		resp, isUserError, err := plugin.runGetDebugPacketCommand([]string{"gabesinstall2"}, &model.CommandArgs{UserId: "gabeid2"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no installation with the name gabesinstall2 found")
+		assert.True(t, isUserError)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("no cluster installations", func(t *testing.T) {
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"gabeid\", \"Name\": \"gabesinstall\"}]"), nil)
+		mockedCloudClient.mockedCloudClusterInstallations = []*cloud.ClusterInstallation{}
+
+		resp, isUserError, err := plugin.runGetDebugPacketCommand([]string{"gabesinstall", "version"}, &model.CommandArgs{UserId: "gabeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no cluster installations found for installation")
+		assert.False(t, isUserError)
+		assert.Nil(t, resp)
+	})
+}

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -105,6 +105,10 @@ func (mc *MockClient) RunMmctlCommandOnClusterInstallation(clusterInstallationID
 	return []byte("mocked mmctl command output"), nil
 }
 
+func (mc *MockClient) ExecClusterInstallationPPROF(clusterInstallationID string) ([]byte, error) {
+	return []byte("mocked debug packet output"), nil
+}
+
 func (mc *MockClient) GetGroup(groupID string) (*cloud.GroupDTO, error) {
 	return &cloud.GroupDTO{Group: &cloud.Group{ID: groupID, Name: "test-group"}}, nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -50,6 +50,7 @@ type CloudClient interface {
 	GetClusterInstallations(request *cloud.GetClusterInstallationsRequest) ([]*cloud.ClusterInstallation, error)
 	RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error)
 	ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error)
+	ExecClusterInstallationPPROF(clusterInstallationID string) ([]byte, error)
 
 	GetGroup(groupID string) (*cloud.GroupDTO, error)
 }

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -193,6 +193,10 @@ export function restartInstallation(name) {
     return executeCommand(`/cloud restart ${name}`);
 }
 
+export function getDebugPacket(name) {
+    return executeCommand(`/cloud debug-packet ${name}`);
+}
+
 export const telemetry = (event, properties) => async (dispatch, getState) => {
     await fetch(getPluginServerRoute(getState()) + '/telemetry', Client4.getOptions({
         method: 'post',

--- a/webapp/src/components/sidebar_right/index.js
+++ b/webapp/src/components/sidebar_right/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 
-import {telemetry, setRhsVisible, getCloudUserData, getSharedInstalls, restartInstallation, deletionLockInstallation, deletionUnlockInstallation, getPluginConfiguration} from '../../actions';
+import {telemetry, setRhsVisible, getCloudUserData, getSharedInstalls, restartInstallation, getDebugPacket, deletionLockInstallation, deletionUnlockInstallation, getPluginConfiguration} from '../../actions';
 
 import {installsForUser, sharedInstalls, serverError, pluginConfiguration} from '../../selectors';
 
@@ -30,6 +30,7 @@ function mapDispatchToProps(dispatch) {
             getSharedInstalls,
             setVisible: setRhsVisible,
             restartInstallation,
+            getDebugPacket,
             deletionLockInstallation,
             deletionUnlockInstallation,
             getPluginConfiguration,

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -47,6 +47,7 @@ export default class SidebarRight extends React.PureComponent {
             getCloudUserData: PropTypes.func.isRequired,
             getSharedInstalls: PropTypes.func.isRequired,
             restartInstallation: PropTypes.func.isRequired,
+            getDebugPacket: PropTypes.func.isRequired,
             deletionLockInstallation: PropTypes.func.isRequired,
             deletionUnlockInstallation: PropTypes.func.isRequired,
             getPluginConfiguration: PropTypes.func.isRequired,
@@ -82,10 +83,11 @@ export default class SidebarRight extends React.PureComponent {
         const dropdownButtonItems = [
             {onClick: () => window.open(installation.InstallationLogsURL, '_blank'), buttonText: 'Installation Logs'},
             {onClick: () => window.open(installation.ProvisionerLogsURL, '_blank'), buttonText: 'Provisioner Logs'},
+            {onClick: () => this.handleGetDebugPacket(installation.Name), buttonText: 'Get Debug Packet'},
         ];
         const menuItems = dropdownButtonItems.map((menuItem, index) => (
             <MenuItem
-                key={'log-menu-' + installation.ID + '-' + index}
+                key={'debug-menu-' + installation.ID + '-' + index}
                 onClick={menuItem.onClick}
             >{menuItem.buttonText}
             </MenuItem>
@@ -114,7 +116,7 @@ export default class SidebarRight extends React.PureComponent {
                 <DropdownButton
                     style={style.dropdownButton}
                     className='btn btn-tertiary btn-sm'
-                    title='Logs'
+                    title='Debug'
                 >
                     {menuItems}
                 </DropdownButton>
@@ -138,6 +140,10 @@ export default class SidebarRight extends React.PureComponent {
             onCancel: () => this.setState({confirmationModal: {visible: false}}),
         }});
     }
+
+    handleGetDebugPacket = async (name) => {
+        await this.props.actions.getDebugPacket(name);
+    };
 
     async handleDeletionUnlock(installation) {
         await this.props.actions.deletionUnlockInstallation(installation.ID);


### PR DESCRIPTION
This allows for the cloud plugin to request a debug packet for a given installation via the cloud provisioner. The packet currently contains pprof data for each Mattermost server instance in the server cluster.

-----

<img width="387" alt="Screenshot 2024-11-27 at 10 36 05 AM" src="https://github.com/user-attachments/assets/7d927e3d-59da-4d01-b666-c1ee573805e5">

-----

<img width="384" alt="Screenshot 2024-11-27 at 10 36 51 AM" src="https://github.com/user-attachments/assets/ce167560-5e92-4720-9318-ee92c9eed1f6">


Fixes https://mattermost.atlassian.net/browse/CLD-8609

```release-note
Add debug packet functionality
```
