### PR TITLE
[CLD-8682] Support for 24h deletion pending window in test env

### DIFF
--- a/server/command_create.go
+++ b/server/command_create.go
@@ -189,7 +189,7 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 		return nil, false, errors.Wrap(err, "unable to determine if installation name is already taken")
 	}
 	if exists {
-		return nil, true, errors.Errorf("Installation name %s already exists. Names are case insensitive and must be unique so you must choose a new name and try again", install.Name)
+		return nil, true, errors.Errorf("Installation name %s already exists. **NOTE**: installation names are reserved for 24 hours after deletion in order to support restoration. Please try a new name, wait 24 hours, or contact the Cloud Platform team for support.", install.Name)
 	}
 
 	err = p.parseCreateArgs(args, install)

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -237,6 +237,9 @@ func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*mod
 
 	cloudInstallation, err := p.cloudClient.CreateInstallation(req)
 	if err != nil {
+		if strings.Contains(err.Error(), "409") {
+			return nil, true, errors.Errorf("Installation name %s already exists. **NOTE**: installation names are reserved for 24 hours after deletion in order to support restoration. Please try a new name, wait 24 hours, or contact the Cloud Platform team for support.", install.Name)
+		}
 		return nil, false, errors.Wrap(err, "failed to create installation")
 	}
 

--- a/server/command_list.go
+++ b/server/command_list.go
@@ -103,7 +103,6 @@ func (p *Plugin) getUpdatedInstallsForUser(userID string, hideSensitive bool) ([
 		if deleted {
 			// Notify the user and also show the deleted installation in their
 			// list one last time with a DELETED tag.
-			p.PostBotDM(userID, fmt.Sprintf("Cloud installation %s has been manually deleted and is now removed from the cloud plugin.\n\n%s", pluginInstall.Name, jsonCodeBlock(pluginInstall.ToPrettyJSON())))
 			pluginInstalls[i] = &Installation{
 				Name: fmt.Sprintf("%s [ DELETED ]", pluginInstall.Name),
 			}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -132,8 +132,9 @@ func (p *Plugin) processWebhookEvent(payload *cloud.WebhookPayload) {
 	if payload.NewState == cloud.InstallationStateDeletionPending {
 		if payload.ExtraData["actor_id"] == p.configuration.ProvisioningServerClientID {
 			p.PostBotDM(install.OwnerID, fmt.Sprintf("Installation %s is pending final deletion. If this was a mistake, please contact the Cloud Platform team within 24 hours of this message, or your data will be lost forever.", install.Name))
+			return
 		}
-		p.PostBotDM(install.OwnerID, fmt.Sprintf("Installation %s is pending deletion. If you believe this to be a mistake, please contact the Cloud Platform team for restoration. You have 24 hours to initiate before your data is lost forever.", install.Name))
+		p.PostBotDM(install.OwnerID, fmt.Sprintf("Installation %s has automatically been moved to pending deletion state. If you believe this to be a mistake, please contact the Cloud Platform team for restoration. You have 24 hours to initiate before your data is lost forever.", install.Name))
 		return
 	}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -94,7 +94,9 @@ func (p *Plugin) processWebhookEvent(payload *cloud.WebhookPayload) {
 	}
 
 	if payload.NewState != cloud.InstallationStateStable &&
-		payload.NewState != cloud.InstallationStateHibernating {
+		payload.NewState != cloud.InstallationStateHibernating &&
+		payload.NewState != cloud.InstallationStateDeletionPending &&
+		payload.NewState != cloud.InstallationStateDeleted {
 		return
 	}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -127,6 +127,19 @@ func (p *Plugin) processWebhookEvent(payload *cloud.WebhookPayload) {
 		return
 	}
 
+	if payload.NewState == cloud.InstallationStateDeletionPending {
+		if payload.ExtraData["actor_id"] == p.configuration.ProvisioningServerClientID {
+			p.PostBotDM(install.OwnerID, fmt.Sprintf("Installation %s is pending final deletion. If this was a mistake, please contact the Cloud Platform team within 24 hours of this message, or your data will be lost forever.", install.Name))
+		}
+		p.PostBotDM(install.OwnerID, fmt.Sprintf("Installation %s is pending deletion. If you believe this to be a mistake, please contact the Cloud Platform team for restoration. You have 24 hours to initiate before your data is lost forever.", install.Name))
+		return
+	}
+
+	if payload.NewState == cloud.InstallationStateDeleted {
+		p.PostBotDM(install.OwnerID, fmt.Sprintf("Installation %s has been deleted", install.Name))
+		return
+	}
+
 	var dnsRecord string
 	if len(install.DNSRecords) > 0 {
 		dnsRecord = install.DNSRecords[0].DomainName


### PR DESCRIPTION
#### Summary
This PR adjusts how informative the error is when attempting to create an installation with a name that is already reserved. The plugin already checks for existence, so that error was adjusted, but I've also added a check for a 409 return from the Provisioner if that initial lookup fails for whatever reason. 

This PR also changes the "installation deleted" message to be webhook-driven - it will compare actor_id from the incoming webhook to the client ID the plugin has been assigned for authentication - if they're the same, it knows the action was completed by the plugin, so the message is adjusted (ie, deleted manually). If not, it knows that the installation was deleted via an automated process. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8628
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
