### PR TITLE
Standardize Mattermost env output

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -146,7 +146,7 @@ func (p *Plugin) handleSharedInstalls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sharedInstalls, err := p.getUpdatedSharedInstallations()
+	sharedInstalls, err := p.getUpdatedSharedInstallations(false)
 	if err != nil {
 		p.API.LogError(errors.Wrap(err, "Unable to getUpdatedSharedInstallations").Error())
 		http.Error(w, "Internal server error", http.StatusInternalServerError)

--- a/server/command_list.go
+++ b/server/command_list.go
@@ -45,7 +45,7 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (*model
 
 	var installs []*Installation
 	if config.Shared {
-		installs, err = p.getUpdatedSharedInstallations()
+		installs, err = p.getUpdatedSharedInstallations(true)
 		if err != nil {
 			return nil, false, err
 		}

--- a/server/installation.go
+++ b/server/installation.go
@@ -250,7 +250,7 @@ func (p *Plugin) getUpdatableInstallationsForUser(userID string, includeShared b
 	return updatableInstallsForUser, nil
 }
 
-func (p *Plugin) getUpdatedSharedInstallations() ([]*Installation, error) {
+func (p *Plugin) getUpdatedSharedInstallations(hideSensitive bool) ([]*Installation, error) {
 	sharedInstalls, err := p.getSharedInstallations()
 	if err != nil {
 		return nil, err
@@ -268,6 +268,9 @@ func (p *Plugin) getUpdatedSharedInstallations() ([]*Installation, error) {
 			return nil, fmt.Errorf("could not find installation %s", install.ID)
 		}
 		install.InstallationDTO = *updatedInstall
+		if hideSensitive {
+			install.HideSensitiveFields()
+		}
 	}
 
 	return sharedInstalls, nil

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -123,6 +123,7 @@ func (p *Plugin) processWebhookEvent(payload *cloud.WebhookPayload) {
 		return
 	}
 	install.Installation = installation.Installation
+	install.HideSensitiveFields()
 
 	if payload.NewState == cloud.InstallationStateHibernating {
 		p.PostBotDM(install.OwnerID, fmt.Sprintf("Installation %s has been hibernated", install.Name))


### PR DESCRIPTION
This standardizes how env output is shown across different commands.

```release-note
Standardize Mattermost env output
```
