### PR TITLE
Add mattermost/mattermost-enterprise-edition-fips as a valid image repo

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -184,7 +184,7 @@ func (p *Plugin) getCommand() *model.Command {
 						},
 						{
 							Name:     "image",
-							HelpText: "Docker image repository, can be mattermost/mattermost-enterprise-edition, mattermost/mm-ee-cloud, mattermost/mm-te, mattermost/mattermost-team-edition, mattermostdevelopment/mm-ee-test, mattermostdevelopment/mm-te-test, mattermostdevelopment/mattermost-enterprise-edition, mattermostdevelopment/mattermost-team-edition",
+							HelpText: "Docker image repository, can be mattermost/mattermost-enterprise-edition, mattermost/mm-ee-cloud, mattermost/mm-te, mattermost/mattermost-team-edition, mattermostdevelopment/mm-ee-test, mattermostdevelopment/mm-te-test, mattermostdevelopment/mattermost-enterprise-edition, mattermostdevelopment/mattermost-team-edition, mattermost/mattermost-enterprise-edition-fips",
 							Required: false,
 						},
 						{
@@ -215,7 +215,7 @@ func (p *Plugin) getCommand() *model.Command {
 								Hint: "image",
 							},
 							Name:     "image",
-							HelpText: "Docker image repository. Can be mattermost/mattermost-enterprise-edition, mattermost/mm-ee-cloud, mattermost/mm-te, mattermost/mattermost-team-edition, mattermostdevelopment/mm-ee-test, mattermostdevelopment/mm-te-test, mattermostdevelopment/mattermost-enterprise-edition, mattermostdevelopment/mattermost-team-edition (default \"mattermost/mattermost-enterprise-edition\")",
+							HelpText: "Docker image repository. Can be mattermost/mattermost-enterprise-edition, mattermost/mm-ee-cloud, mattermost/mm-te, mattermost/mattermost-team-edition, mattermostdevelopment/mm-ee-test, mattermostdevelopment/mm-te-test, mattermostdevelopment/mattermost-enterprise-edition, mattermostdevelopment/mattermost-team-edition, mattermost/mattermost-enterprise-edition-fips (default \"mattermost/mattermost-enterprise-edition\")",
 							Required: false,
 						},
 						{

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -17,6 +17,7 @@ const (
 
 	imageEE          = "mattermost/mattermost-enterprise-edition"
 	imageEECloud     = "mattermost/mm-ee-cloud"
+	imageEEFips      = "mattermost/mattermost-enterprise-edition-fips"
 	imageTE          = "mattermost/mm-te"
 	imageTeamEdition = "mattermost/mattermost-team-edition"
 	imageEETest      = "mattermostdevelopment/mm-ee-test"
@@ -40,6 +41,7 @@ var validLicenseOptions = []string{
 var dockerRepoWhitelist = []string{
 	imageEE,
 	imageEECloud,
+	imageEEFips,
 	imageTE,
 	imageTeamEdition,
 	imageEETest,


### PR DESCRIPTION
#### Summary
Add mattermost/mattermost-enterprise-edition-fips as a valid image repo.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9024
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add mattermost/mattermost-enterprise-edition-fips as a valid image repo
```
