### PR TITLE
Bump to version 0.1.40

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.cloud",
     "name": "Mattermost Private Cloud",
     "description": "This plugin allows spinning up and down Mattermost installations using Mattermost Private Cloud.",
-    "version": "0.1.39",
+    "version": "0.1.40",
     "min_server_version": "8.1.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "com.mattermost.cloud",
-	Version: "0.1.39",
+	Version: "0.1.40",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'com.mattermost.cloud';
-export const version = '0.1.39';
+export const version = '0.1.40';


### PR DESCRIPTION
This pull request updates the plugin version from 0.1.39 to 0.1.40 across the project to ensure consistency in versioning.

Version bump:

* Updated the version number to 0.1.40 in `plugin.json` to reflect the new release.
* Updated the version number in the `manifest` struct in `server/manifest.go` to 0.1.40.
* Updated the version export in `webapp/src/manifest.js` to 0.1.40.



```release-note
Replace heroku docker library
```
