### PR TITLE
Add typed installation service layer and harden helpers

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -35,11 +35,11 @@ func CreateInstallationWebWrapper(i *Installation) (*InstallationWebWrapper, err
 	}
 
 	serviceEnvironment := getInstallationServiceEnvironment(i)
-	i.HideSensitiveFields()
+	sanitizedInstall := sanitizeInstallationCopy(i)
 
 	return &InstallationWebWrapper{
-		Installation:        i,
-		CreateAtDate:        cloud.DateStringFromMillis(i.CreateAt),
+		Installation:        sanitizedInstall,
+		CreateAtDate:        cloud.DateStringFromMillis(sanitizedInstall.CreateAt),
 		ServiceEnvironment:  serviceEnvironment,
 		InstallationLogsURL: installationLogsURL,
 		ProvisionerLogsURL:  provisionerLogsURL,
@@ -191,9 +191,7 @@ func (p *Plugin) handleDeletionLock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Lock for deletion needs to fetch all installations and ensure ownership to validate
-	// users aren't locking more than one, so there's no need to check ownership here.
-	err = p.lockForDeletion(req.InstallationID, userID)
+	_, err = p.setDeletionLockForUser(userID, InstallationRef{ID: req.InstallationID}, true)
 	if err != nil {
 		p.API.LogError(errors.Wrap(err, "Unable to lock for deletion").Error())
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -228,9 +226,7 @@ func (p *Plugin) handleDeletionUnlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Unlock for deletion needs to fetch all installations and ensure ownership to validate
-	// users aren't unlocking more than one, so there's no need to check ownership here.
-	err = p.unlockForDeletion(req.InstallationID, userID)
+	_, err = p.setDeletionLockForUser(userID, InstallationRef{ID: req.InstallationID}, false)
 	if err != nil {
 		p.API.LogError(errors.Wrap(err, "Unable to unlock for deletion").Error())
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -266,6 +262,9 @@ func (p *Plugin) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func getInstallationServiceEnvironment(installation *Installation) string {
+	if installation == nil || installation.Installation == nil {
+		return "production"
+	}
 	if v, ok := installation.PriorityEnv[serviceEnvironmentEnvVarKey]; ok {
 		return v.Value
 	}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeletionLockHandlers(t *testing.T) {
+	t.Run("lock returns created with request body", func(t *testing.T) {
+		target := serviceTestInstall("target-id", "Target", "owner")
+		plugin, cloudClient, _ := newServiceTestPlugin(t, []*Installation{target})
+		cloudClient.mockedCloudInstallationsDTO = serviceDTOs(target)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/deletion-lock", strings.NewReader(`{"installation_id":"target-id"}`))
+		req.Header.Set("Mattermost-User-ID", "owner")
+		rec := httptest.NewRecorder()
+
+		plugin.handleDeletionLock(rec, req)
+
+		require.Equal(t, http.StatusCreated, rec.Code)
+		assert.JSONEq(t, `{"installation_id":"target-id"}`, rec.Body.String())
+		assert.Equal(t, "target-id", cloudClient.lockedInstallationID)
+	})
+
+	t.Run("unlock returns created with request body", func(t *testing.T) {
+		target := serviceTestInstall("target-id", "Target", "owner")
+		target.DeletionLocked = true
+		plugin, cloudClient, _ := newServiceTestPlugin(t, []*Installation{target})
+		cloudClient.mockedCloudInstallationsDTO = serviceDTOs(target)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/deletion-unlock", strings.NewReader(`{"installation_id":"target-id"}`))
+		req.Header.Set("Mattermost-User-ID", "owner")
+		rec := httptest.NewRecorder()
+
+		plugin.handleDeletionUnlock(rec, req)
+
+		require.Equal(t, http.StatusCreated, rec.Code)
+		assert.JSONEq(t, `{"installation_id":"target-id"}`, rec.Body.String())
+		assert.Equal(t, "target-id", cloudClient.unlockedInstallationID)
+	})
+
+	t.Run("wrong owner keeps existing internal error behavior", func(t *testing.T) {
+		target := serviceTestInstall("target-id", "Target", "owner")
+		plugin, _, api := newServiceTestPlugin(t, []*Installation{target})
+		api.On("LogError", mock.AnythingOfType("string")).Return(nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/deletion-lock", strings.NewReader(`{"installation_id":"target-id"}`))
+		req.Header.Set("Mattermost-User-ID", "other")
+		rec := httptest.NewRecorder()
+
+		plugin.handleDeletionLock(rec, req)
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Contains(t, rec.Body.String(), "Internal server error")
+	})
+}

--- a/server/command_create.go
+++ b/server/command_create.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -55,215 +54,104 @@ func (p *Plugin) getCreateFlagSet() *flag.FlagSet {
 	return createFlagSet
 }
 
-// parseCreateArgs is responsible for reading in arguments and basic input validation
-func (p *Plugin) parseCreateArgs(args []string, install *Installation) error {
-	createFlagSet := p.getCreateFlagSet()
-	err := createFlagSet.Parse(args)
-	if err != nil {
-		return err
-	}
-
-	install.Size, err = createFlagSet.GetString("size")
-	if err != nil {
-		return err
-	}
-	if install.Size != "" && !Contains(validInstallationSizes, install.Size) {
-		return fmt.Errorf("Invalid size: %s", install.Size)
-	}
-
-	install.Version, err = createFlagSet.GetString("version")
-	if err != nil {
-		return err
-	}
-
-	if install.Version == "latest" {
-		install.Version, err = p.githubLatestVersion()
-		if err != nil {
-			return errors.Wrap(err, "failed to determine latest tag for requested version 'latest'")
-		}
-		if install.Version == "" {
-			return errors.New("failed to determine latest tag for requested version 'latest': got empty version")
-		}
-	}
-	install.Tag = install.Version
-
-	install.Affinity, err = createFlagSet.GetString("affinity")
-	if err != nil {
-		return err
-	}
-
-	if !cloud.IsSupportedAffinity(install.Affinity) {
-		return errors.Errorf("invalid affinity option %s, must be %s or %s", install.Affinity, cloud.InstallationAffinityIsolated, cloud.InstallationAffinityMultiTenant)
-	}
-
-	install.License, err = createFlagSet.GetString("license")
-	if err != nil {
-		return err
-	}
-
-	if !validLicenseOption(install.License) {
-		return errors.Errorf("invalid license option %s, valid options are %s", install.License, strings.Join(validLicenseOptions, ", "))
-	}
-
-	install.Image, err = createFlagSet.GetString("image")
-	if err != nil {
-		return err
-	}
-
-	if !validImageName(install.Image) {
-		return errors.Errorf("invalid image name %s, valid options are %s", install.Image, strings.Join(dockerRepoWhitelist, ", "))
-	}
-
-	install.Database, err = createFlagSet.GetString("database")
-	if err != nil {
-		return err
-	}
-
-	if !cloud.IsSupportedDatabase(install.Database) {
-		return errors.Errorf("invalid database option %s; valid options are: %s, %s, %s",
-			install.Database,
-			cloud.InstallationDatabasePerseus,
-			cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
-			cloud.InstallationDatabaseMysqlOperator,
-		)
-	}
-
-	install.Filestore, err = createFlagSet.GetString("filestore")
-	if err != nil {
-		return err
-	}
-
-	if !cloud.IsSupportedFilestore(install.Filestore) {
-		return errors.Errorf("invalid filestore option %s; must be %s, %s, %s, or %s",
-			install.Filestore,
-			cloud.InstallationFilestoreBifrost,
-			cloud.InstallationFilestoreMinioOperator,
-			cloud.InstallationFilestoreAwsS3,
-			cloud.InstallationFilestoreMultiTenantAwsS3,
-		)
-	}
-
-	if install.Filestore == cloud.InstallationFilestoreMultiTenantAwsS3 && install.License != licenseOptionEnterprise && install.License != licenseOptionE20 && install.License != licenseOptionEnterpriseAdvanced {
-		return errors.Errorf("filestore option %s requires license option %s or %s or %s", cloud.InstallationFilestoreMultiTenantAwsS3, licenseOptionEnterprise, licenseOptionE20, licenseOptionEnterpriseAdvanced)
-	}
-
-	install.TestData, err = createFlagSet.GetBool("test-data")
-	if err != nil {
-		return err
-	}
-
-	envVars, err := createFlagSet.GetStringSlice("env")
-	if err != nil {
-		return err
-	}
-	envVarMap, err := parseEnvVarInput(envVars, nil)
-	if err != nil {
-		return err
-	}
-	install.PriorityEnv = envVarMap
-
-	return nil
-}
-
 func (p *Plugin) runCreateCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
 	if len(args) == 0 {
 		return nil, true, errors.New("must provide an installation name")
 	}
 
-	install := &Installation{
-		Name: standardizeName(args[0]),
-		InstallationDTO: cloud.InstallationDTO{
-			Installation: &cloud.Installation{},
-		},
-	}
-
-	if install.Name == "" || strings.HasPrefix(install.Name, "--") {
-		return nil, true, errors.New("must provide an installation name")
-	}
-
-	if !validInstallationName(install.Name) {
-		return nil, true, errors.Errorf("installation name %s is invalid: only letters, numbers, and hyphens are permitted", install.Name)
-	}
-
-	exists, err := p.installationWithNameExists(install.Name)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "unable to determine if installation name is already taken")
-	}
-	if exists {
-		return nil, true, errors.Errorf("Installation name %s already exists. **NOTE**: installation names are reserved for 24 hours after deletion in order to support restoration. Please try a new name, wait 24 hours, or contact the Cloud Platform team for support.", install.Name)
-	}
-
-	err = p.parseCreateArgs(args, install)
+	input, err := p.createInstallationInputFromArgs(args)
 	if err != nil {
 		return nil, true, err
 	}
 
-	err = validVersionOption(install.Version)
+	install, err := p.createInstallationForUser(extra.UserId, input)
 	if err != nil {
-		return nil, true, errors.Wrap(err, "Invalid version number")
-	}
-
-	validTag, err := p.dockerClient.ValidTag(install.Version, install.Image)
-	if err != nil {
-		p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", install.Image, install.Version).Error())
-	}
-	if !validTag {
-		return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, install.Image)
-	}
-
-	var digest string
-	digest, err = p.dockerClient.GetDigestForTag(install.Version, install.Image)
-	if err != nil {
-		return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
-	}
-	install.Version = digest
-
-	config := p.getConfiguration()
-
-	req := &cloud.CreateInstallationRequest{
-		Name:        install.Name,
-		OwnerID:     extra.UserId,
-		GroupID:     config.GroupID,
-		Affinity:    install.Affinity,
-		DNSNames:    []string{fmt.Sprintf("%s.%s", install.Name, config.InstallationDNS)},
-		Database:    install.Database,
-		Filestore:   install.Filestore,
-		PriorityEnv: install.PriorityEnv,
-		License:     p.getLicenseValue(install.License),
-		Size:        install.Size,
-		Version:     install.Version,
-		Image:       install.Image,
-		Annotations: []string{defaultMultiTenantAnnotation},
-	}
-
-	var hours int
-	if config.ScheduledDeletionHours != "" && config.ScheduledDeletionHours != "0" {
-		hours, err = strconv.Atoi(config.ScheduledDeletionHours)
-		if err == nil && hours > 0 {
-			// Convert hours to milliseconds and add to current time
-			deletionTime := time.Now().Add(time.Duration(hours) * time.Hour).UnixMilli()
-			req.ScheduledDeletionTime = deletionTime
+		if isCreateUserError(err) {
+			return nil, true, err
 		}
-	}
-
-	cloudInstallation, err := p.cloudClient.CreateInstallation(req)
-	if err != nil {
-		if strings.Contains(err.Error(), "409") {
-			return nil, true, errors.Errorf("Installation name %s already exists. **NOTE**: installation names are reserved for 24 hours after deletion in order to support restoration. Please try a new name, wait 24 hours, or contact the Cloud Platform team for support.", install.Name)
-		}
-		return nil, false, errors.Wrap(err, "failed to create installation")
-	}
-
-	install.Installation = cloudInstallation.Installation
-
-	err = p.storeInstallation(install)
-	if err != nil {
 		return nil, false, err
 	}
 
-	install.HideSensitiveFields()
+	install = sanitizeInstallationCopy(install)
 
 	return getCommandResponse(model.CommandResponseTypeEphemeral, "Installation being created. You will receive a notification when it is ready. Use `/cloud list` to check on the status of your installations.\n\n"+jsonCodeBlock(install.ToPrettyJSON()), extra), false, nil
+}
+
+func (p *Plugin) createInstallationInputFromArgs(args []string) (CreateInstallationInput, error) {
+	if len(args) == 0 || args[0] == "" || strings.HasPrefix(args[0], "--") {
+		return CreateInstallationInput{}, errors.New("must provide an installation name")
+	}
+
+	createFlagSet := p.getCreateFlagSet()
+	if err := createFlagSet.Parse(args); err != nil {
+		return CreateInstallationInput{}, err
+	}
+
+	envVars, err := createFlagSet.GetStringSlice("env")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	envMap, err := parseEnvVarInput(envVars, nil)
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+
+	input := CreateInstallationInput{Name: args[0], Env: map[string]string{}}
+	input.Size, err = createFlagSet.GetString("size")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	input.Version, err = createFlagSet.GetString("version")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	input.Affinity, err = createFlagSet.GetString("affinity")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	input.License, err = createFlagSet.GetString("license")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	input.Image, err = createFlagSet.GetString("image")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	input.Database, err = createFlagSet.GetString("database")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	input.Filestore, err = createFlagSet.GetString("filestore")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	input.TestData, err = createFlagSet.GetBool("test-data")
+	if err != nil {
+		return CreateInstallationInput{}, err
+	}
+	for key, env := range envMap {
+		input.Env[key] = env.Value
+	}
+
+	return input, nil
+}
+
+func isCreateUserError(err error) bool {
+	errText := err.Error()
+	return strings.Contains(errText, "must provide an installation name") ||
+		strings.Contains(errText, "is invalid: only letters, numbers, and hyphens are permitted") ||
+		strings.Contains(errText, "already exists") ||
+		strings.Contains(errText, "Invalid version number") ||
+		strings.Contains(errText, "is not a valid docker tag") ||
+		strings.Contains(errText, "Invalid size:") ||
+		strings.Contains(errText, "invalid affinity option") ||
+		strings.Contains(errText, "invalid license option") ||
+		strings.Contains(errText, "invalid image name") ||
+		strings.Contains(errText, "invalid database option") ||
+		strings.Contains(errText, "invalid filestore option") ||
+		strings.Contains(errText, "requires license option") ||
+		strings.Contains(errText, "valid env format") ||
+		strings.Contains(errText, "defined more than once")
 }
 
 // installationWithNameExists returns true when there already exists an installation with name "name"

--- a/server/command_create_test.go
+++ b/server/command_create_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
 	cloud "github.com/mattermost/mattermost-cloud/model"
@@ -16,8 +18,9 @@ func TestCreateCommand(t *testing.T) {
 	dockerClient := &MockedDockerClient{tagExists: true}
 	mockCloudClient := &MockClient{}
 	plugin := Plugin{
-		cloudClient:  mockCloudClient,
-		dockerClient: dockerClient,
+		cloudClient:             mockCloudClient,
+		dockerClient:            dockerClient,
+		latestMattermostVersion: &latestMattermostVersionCache{version: "9.5.0", timestamp: time.Now()},
 	}
 
 	api := &plugintest.API{}
@@ -281,14 +284,16 @@ func TestCreateCommand(t *testing.T) {
 
 	t.Run("env vars", func(t *testing.T) {
 		t.Run("valid env vars", func(t *testing.T) {
-			expectedEnv := cloud.EnvVarMap{"ENV1": cloud.EnvVar{Value: "test"}, "ENV2": cloud.EnvVar{Value: "test2"}}
+			expectedEnv := cloud.EnvVarMap{"ENV1": cloud.EnvVar{Value: "priority-secret-value"}, "ENV2": cloud.EnvVar{Value: "another-secret-value"}}
 
-			resp, isUserError, err := plugin.runCreateCommand([]string{"test", "--version", "5.30.0", "--env", "ENV1=test,ENV2=test2"}, &model.CommandArgs{})
+			resp, isUserError, err := plugin.runCreateCommand([]string{"test", "--version", "5.30.0", "--env", "ENV1=priority-secret-value,ENV2=another-secret-value"}, &model.CommandArgs{})
 			require.NoError(t, err)
 			assert.False(t, isUserError)
 			assert.Contains(t, resp.Text, "Installation being created.")
 			require.NotNil(t, mockCloudClient.creationRequest)
 			assert.Equal(t, expectedEnv, mockCloudClient.creationRequest.PriorityEnv)
+			assert.NotContains(t, resp.Text, "priority-secret-value")
+			assert.NotContains(t, resp.Text, "another-secret-value")
 		})
 		t.Run("invalid env vars", func(t *testing.T) {
 			_, isUserError, err := plugin.runCreateCommand([]string{"test", "--version", "5.30.0", "--env", "ENV1:test"}, &model.CommandArgs{})
@@ -296,6 +301,24 @@ func TestCreateCommand(t *testing.T) {
 			assert.True(t, isUserError)
 			assert.Contains(t, err.Error(), "ENV1:test is not in a valid env format")
 		})
+	})
+
+	t.Run("installation lookup failures are internal errors", func(t *testing.T) {
+		lookupFailurePlugin := Plugin{
+			cloudClient:             &MockClient{},
+			dockerClient:            &MockedDockerClient{tagExists: true},
+			latestMattermostVersion: &latestMattermostVersionCache{version: "9.5.0", timestamp: time.Now()},
+		}
+
+		api := &plugintest.API{}
+		api.On("KVGet", mock.AnythingOfType("string")).Return(nil, model.NewAppError("test", "kv_get_failed", nil, "kv lookup failed", http.StatusInternalServerError))
+		lookupFailurePlugin.SetAPI(api)
+
+		resp, isUserError, err := lookupFailurePlugin.runCreateCommand([]string{"test"}, &model.CommandArgs{})
+		require.Error(t, err)
+		assert.False(t, isUserError)
+		assert.Nil(t, resp)
+		assert.Contains(t, err.Error(), "unable to determine if installation name is already taken")
 	})
 
 	t.Run("missing installation name", func(t *testing.T) {

--- a/server/command_delete.go
+++ b/server/command_delete.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -13,32 +14,11 @@ func (p *Plugin) runDeleteCommand(args []string, extra *model.CommandArgs) (*mod
 
 	name := standardizeName(args[0])
 
-	installs, _, err := p.getInstallations()
+	_, err := p.deleteInstallationForUser(extra.UserId, InstallationRef{Name: name}, name)
 	if err != nil {
-		return nil, false, err
-	}
-
-	var installToDelete *Installation
-	for _, install := range installs {
-		if install.OwnerID == extra.UserId && standardizeName(install.Name) == name {
-			installToDelete = install
-			break
+		if strings.Contains(err.Error(), "no installation with the name") {
+			return nil, true, err
 		}
-	}
-
-	if installToDelete == nil {
-		return nil, true, fmt.Errorf("no installation with the name %s found", name)
-	}
-
-	// Delete the installation before removing it from the database in case we
-	// encounter an error.
-	err = p.cloudClient.DeleteInstallation(installToDelete.ID)
-	if err != nil {
-		return nil, false, err
-	}
-
-	err = p.deleteInstallation(installToDelete.ID)
-	if err != nil {
 		return nil, false, err
 	}
 

--- a/server/command_deletion_lock.go
+++ b/server/command_deletion_lock.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
 )
@@ -12,41 +9,7 @@ func (p *Plugin) lockForDeletion(installationID string, userID string) error {
 	if installationID == "" {
 		return errors.New("installationID must not be empty")
 	}
-	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(userID)
-	if err != nil {
-		return err
-	}
-
-	if len(installations) == 0 {
-		return errors.New("no installations found for the given User ID")
-	}
-
-	maxLockedInstallations, err := strconv.Atoi(p.getConfiguration().DeletionLockInstallationsAllowedPerPerson)
-	if err != nil {
-		return errors.New("invalid value for DeletionLockInstallationsAllowedPerPerson")
-	}
-
-	numExistingLockedInstallations := 0
-	var installationToLock *Installation
-	for _, install := range installations {
-		if install.OwnerID == userID && install.ID == installationID {
-			installationToLock = install
-			break
-		}
-		if install.OwnerID == userID && install.DeletionLocked {
-			numExistingLockedInstallations++
-		}
-	}
-
-	if maxLockedInstallations <= numExistingLockedInstallations {
-		return fmt.Errorf("you may only have at most %d installations locked for deletion at a time", maxLockedInstallations)
-	}
-
-	if installationToLock == nil {
-		return errors.New("installation to be locked not found")
-	}
-
-	err = p.cloudClient.LockDeletionLockForInstallation(installationToLock.ID)
+	_, err := p.setDeletionLockForUser(userID, InstallationRef{ID: installationID}, true)
 	return err
 }
 
@@ -55,28 +18,7 @@ func (p *Plugin) unlockForDeletion(installationID string, userID string) error {
 		return errors.New("installationID must not be empty")
 	}
 
-	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(userID)
-	if err != nil {
-		return err
-	}
-
-	if len(installations) == 0 {
-		return errors.New("no installations found for the given User ID")
-	}
-
-	var installationToLock *Installation
-	for _, install := range installations {
-		if install.OwnerID == userID && install.ID == installationID {
-			installationToLock = install
-			break
-		}
-	}
-
-	if installationToLock == nil {
-		return errors.New("installation to be unlocked not found")
-	}
-
-	err = p.cloudClient.UnlockDeletionLockForInstallation(installationToLock.ID)
+	_, err := p.setDeletionLockForUser(userID, InstallationRef{ID: installationID}, false)
 	return err
 }
 
@@ -87,24 +29,11 @@ func (p *Plugin) runDeletionLockCommand(args []string, extra *model.CommandArgs)
 
 	name := standardizeName(args[0])
 
-	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	_, err := p.setDeletionLockForUser(extra.UserId, InstallationRef{Name: name}, true)
 	if err != nil {
-		return nil, true, err
-	}
-	var installationIDToLock string
-	for _, installation := range installations {
-		if installation.OwnerID == extra.UserId && installation.Name == name {
-			installationIDToLock = installation.ID
-			break
+		if isDeletionLockMissingTargetError(err) {
+			return nil, true, errors.Errorf("no installation with the name %s found", name)
 		}
-	}
-
-	if installationIDToLock == "" {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-
-	err = p.lockForDeletion(installationIDToLock, extra.UserId)
-	if err != nil {
 		return getCommandResponse(model.CommandResponseTypeEphemeral, err.Error(), extra), false, err
 	}
 
@@ -118,27 +47,23 @@ func (p *Plugin) runDeletionUnlockCommand(args []string, extra *model.CommandArg
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	_, err := p.setDeletionLockForUser(extra.UserId, InstallationRef{Name: name}, false)
 	if err != nil {
-		return nil, false, err
-	}
-
-	var installationIDToUnlock string
-	for _, install := range installs {
-		if install.OwnerID == extra.UserId && install.Name == name {
-			installationIDToUnlock = install.ID
-			break
+		if isDeletionLockMissingTargetError(err) {
+			return nil, true, errors.Errorf("no installation with the name %s found", name)
 		}
-	}
-
-	if installationIDToUnlock == "" {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-
-	err = p.unlockForDeletion(installationIDToUnlock, extra.UserId)
-	if err != nil {
 		return getCommandResponse(model.CommandResponseTypeEphemeral, err.Error(), extra), false, err
 	}
 
 	return getCommandResponse(model.CommandResponseTypeEphemeral, "Deletion lock has been removed, your workspace can now be deleted", extra), false, nil
+}
+
+func isDeletionLockMissingTargetError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return message == "no installations found for the given User ID" ||
+		message == "installation to be locked not found" ||
+		message == "installation to be unlocked not found"
 }

--- a/server/command_deletion_lock_test.go
+++ b/server/command_deletion_lock_test.go
@@ -52,12 +52,14 @@ func TestRunDeletionLockCommand(t *testing.T) {
 		plugin.configuration = &configuration{
 			DeletionLockInstallationsAllowedPerPerson: "1",
 		}
+		mockedCloudClient.lockedInstallationID = ""
 		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"joramsinstall\"}]"), nil)
 
 		commandResponse, _, err := plugin.runDeletionLockCommand([]string{"joramsinstall"}, &model.CommandArgs{UserId: "joramid"})
 
 		require.NoError(t, err)
 		assert.Contains(t, commandResponse.Text, "Deletion lock has been applied, your workspace will be preserved.")
+		assert.Equal(t, "someid", mockedCloudClient.lockedInstallationID)
 	})
 
 	t.Run("no installation found with the given name", func(t *testing.T) {
@@ -90,7 +92,7 @@ func TestLockForDeletion(t *testing.T) {
 	t.Run("Invalid config value", func(t *testing.T) {
 		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"joramsinstall\"}]"), nil)
 
-		err := plugin.lockForDeletion("joramsinstall", "joramid")
+		err := plugin.lockForDeletion("someid", "joramid")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid value for DeletionLockInstallationsAllowedPerPerson")
@@ -102,7 +104,7 @@ func TestLockForDeletion(t *testing.T) {
 		}
 		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"joramsinstall\"}]"), nil)
 
-		err := plugin.lockForDeletion("joramsinstall", "joramid")
+		err := plugin.lockForDeletion("someid", "joramid")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "you may only have at most 0 installations locked for deletion at a time")
@@ -120,9 +122,9 @@ func TestLockForDeletion(t *testing.T) {
 	})
 
 	t.Run("No installations to be locked", func(t *testing.T) {
-		api.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"joramsinstall\"}]"), nil)
 
-		err := plugin.lockForDeletion("joramsinstall", "joramid")
+		err := plugin.lockForDeletion("missingid", "joramid")
 
 		require.EqualError(t, err, "installation to be locked not found")
 	})
@@ -157,12 +159,14 @@ func TestRunDeletionUnlockCommand(t *testing.T) {
 		plugin.configuration = &configuration{
 			DeletionLockInstallationsAllowedPerPerson: "1",
 		}
+		mockedCloudClient.unlockedInstallationID = ""
 		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"joramsinstall\"}]"), nil)
 
 		commandResponse, _, err := plugin.runDeletionUnlockCommand([]string{"joramsinstall"}, &model.CommandArgs{UserId: "joramid"})
 
 		require.NoError(t, err)
 		assert.Contains(t, commandResponse.Text, "Deletion lock has been removed, your workspace can now be deleted")
+		assert.Equal(t, "someid", mockedCloudClient.unlockedInstallationID)
 	})
 
 	t.Run("no installation found with the given name", func(t *testing.T) {
@@ -201,9 +205,9 @@ func TestUnlockForDeletion(t *testing.T) {
 	})
 
 	t.Run("No installations to be unlocked", func(t *testing.T) {
-		api.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+		api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"someid\", \"OwnerID\": \"joramid\", \"Name\": \"joramsinstall\"}]"), nil)
 
-		err := plugin.unlockForDeletion("joramsinstall", "joramid")
+		err := plugin.unlockForDeletion("missingid", "joramid")
 
 		require.EqualError(t, err, "installation to be unlocked not found")
 	})

--- a/server/command_hibernate.go
+++ b/server/command_hibernate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -16,28 +17,12 @@ func (p *Plugin) runHibernateCommand(args []string, extra *model.CommandArgs) (*
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	_, err := p.hibernateInstallationForUser(extra.UserId, InstallationRef{Name: name})
 	if err != nil {
-		return nil, false, err
-	}
-
-	var installToHibernate *Installation
-	for _, install := range installs {
-		if install.OwnerID == extra.UserId && install.Name == name {
-			installToHibernate = install
-			break
+		if strings.Contains(err.Error(), "no installation with the name") ||
+			strings.Contains(err.Error(), fmt.Sprintf("must be %s to hibernate", cloud.InstallationStateStable)) {
+			return nil, true, err
 		}
-	}
-
-	if installToHibernate == nil {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-	if installToHibernate.State != cloud.InstallationStateStable {
-		return nil, true, errors.Errorf("installation state is currently %s and must be %s to hibernate", installToHibernate.State, cloud.InstallationStateStable)
-	}
-
-	_, err = p.cloudClient.HibernateInstallation(installToHibernate.ID)
-	if err != nil {
 		return nil, false, err
 	}
 

--- a/server/command_list.go
+++ b/server/command_list.go
@@ -14,6 +14,11 @@ type listConfig struct {
 	Shared bool
 }
 
+type installationRefreshOptions struct {
+	hideSensitive  bool
+	cleanupDeleted bool
+}
+
 func getListFlagSet() *flag.FlagSet {
 	flagSet := flag.NewFlagSet("list", flag.ContinueOnError)
 	flagSet.Bool("shared-installations", false, "Lists shared installations instead of personal ones")
@@ -43,24 +48,28 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (*model
 		return nil, true, err
 	}
 
-	var installs []*Installation
 	if config.Shared {
-		installs, err = p.getUpdatedSharedInstallations(true)
-		if err != nil {
-			return nil, false, err
+		installs, sharedErr := p.getUpdatedSharedInstallations(false)
+		if sharedErr != nil {
+			return nil, false, sharedErr
 		}
-	} else {
-		installs, err = p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
-		if err != nil {
-			return nil, false, err
-		}
+		return renderInstallationsList(installs, extra)
 	}
 
+	installs, err := p.getUpdatedInstallsForUserWithSensitive(extra.UserId)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return renderInstallationsList(installs, extra)
+}
+
+func renderInstallationsList(installs []*Installation, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
 	if len(installs) == 0 {
 		return getCommandResponse(model.CommandResponseTypeEphemeral, "No installations found.", extra), false, nil
 	}
 
-	data, err := json.Marshal(installs)
+	data, err := marshalInstallationsList(sanitizeInstallationCopies(installs))
 	if err != nil {
 		return nil, false, err
 	}
@@ -68,15 +77,38 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (*model
 	return getCommandResponse(model.CommandResponseTypeEphemeral, jsonCodeBlock(prettyPrintJSON(string(data))), extra), false, nil
 }
 
+func marshalInstallationsList(installs []*Installation) ([]byte, error) {
+	data, err := json.Marshal(installs)
+	if err != nil {
+		return nil, err
+	}
+
+	var rawInstalls []map[string]interface{}
+	if err = json.Unmarshal(data, &rawInstalls); err != nil {
+		return nil, err
+	}
+	for _, install := range rawInstalls {
+		delete(install, "License")
+		delete(install, "MattermostEnv")
+		delete(install, "PriorityEnv")
+	}
+
+	return json.Marshal(rawInstalls)
+}
+
 func (p *Plugin) getUpdatedInstallsForUserWithSensitive(userID string) ([]*Installation, error) {
-	return p.getUpdatedInstallsForUser(userID, false)
+	return p.getUpdatedInstallsForUser(userID, installationRefreshOptions{cleanupDeleted: true})
 }
 
 func (p *Plugin) getUpdatedInstallsForUserWithoutSensitive(userID string) ([]*Installation, error) {
-	return p.getUpdatedInstallsForUser(userID, true)
+	return p.getUpdatedInstallsForUser(userID, installationRefreshOptions{hideSensitive: true, cleanupDeleted: true})
 }
 
-func (p *Plugin) getUpdatedInstallsForUser(userID string, hideSensitive bool) ([]*Installation, error) {
+func (p *Plugin) getRefreshedInstallsForUser(userID string, cleanupDeleted bool) ([]*Installation, error) {
+	return p.getUpdatedInstallsForUser(userID, installationRefreshOptions{cleanupDeleted: cleanupDeleted})
+}
+
+func (p *Plugin) getUpdatedInstallsForUser(userID string, options installationRefreshOptions) ([]*Installation, error) {
 	pluginInstalls, err := p.getInstallationsForUser(userID)
 	if err != nil {
 		return nil, err
@@ -96,29 +128,62 @@ func (p *Plugin) getUpdatedInstallsForUser(userID string, hideSensitive bool) ([
 
 	var deleted bool
 	for i, pluginInstall := range pluginInstalls {
-		deleted, err = p.processInstallationUpdate(pluginInstall, cloudInstalls, hideSensitive)
+		originalID := pluginInstall.ID
+		originalOwnerID := pluginInstall.OwnerID
+		originalCreateAt := pluginInstall.CreateAt
+		deleted, err = p.processInstallationUpdate(pluginInstall, cloudInstalls, options.cleanupDeleted)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to process installation")
 		}
 		if deleted {
 			// Notify the user and also show the deleted installation in their
 			// list one last time with a DELETED tag.
-			pluginInstalls[i] = &Installation{
-				Name: fmt.Sprintf("%s [ DELETED ]", pluginInstall.Name),
-			}
+			pluginInstalls[i] = deletedInstallationPlaceholder(pluginInstall, originalID, originalOwnerID, originalCreateAt)
 		}
+	}
+
+	if options.hideSensitive {
+		return sanitizeInstallationCopies(pluginInstalls), nil
 	}
 
 	return pluginInstalls, nil
 }
 
-func (p *Plugin) processInstallationUpdate(pluginInstall *Installation, cloudInstalls []*cloud.InstallationDTO, hideSensitive bool) (bool, error) {
+func deletedInstallationPlaceholder(source *Installation, id, ownerID string, createAt int64) *Installation {
+	if source == nil {
+		return nil
+	}
+	if id == "" {
+		id = source.ID
+	}
+	if ownerID == "" {
+		ownerID = source.OwnerID
+	}
+	if createAt == 0 {
+		createAt = source.CreateAt
+	}
+
+	return &Installation{
+		Name: fmt.Sprintf("%s [ DELETED ]", source.Name),
+		InstallationDTO: cloud.InstallationDTO{
+			Installation: &cloud.Installation{
+				ID:       id,
+				OwnerID:  ownerID,
+				State:    cloud.InstallationStateDeleted,
+				CreateAt: createAt,
+			},
+		},
+		Tag:                source.Tag,
+		TestData:           source.TestData,
+		Shared:             source.Shared,
+		AllowSharedUpdates: source.AllowSharedUpdates,
+	}
+}
+
+func (p *Plugin) processInstallationUpdate(pluginInstall *Installation, cloudInstalls []*cloud.InstallationDTO, cleanupDeleted bool) (bool, error) {
 	for _, cloudInstall := range cloudInstalls {
 		if pluginInstall.ID == cloudInstall.ID {
 			pluginInstall.InstallationDTO = *cloudInstall
-			if hideSensitive {
-				pluginInstall.HideSensitiveFields()
-			}
 			return false, nil
 		}
 	}
@@ -136,10 +201,7 @@ func (p *Plugin) processInstallationUpdate(pluginInstall *Installation, cloudIns
 		return false, fmt.Errorf("could not find installation %s", pluginInstall.ID)
 	}
 
-	pluginInstall.Installation = updatedInstall.Installation
-	if hideSensitive {
-		pluginInstall.HideSensitiveFields()
-	}
+	pluginInstall.InstallationDTO = *updatedInstall
 
 	if updatedInstall.State != cloud.InstallationStateDeleted {
 		// This is strange as the installation should have been retrieved in the
@@ -149,11 +211,14 @@ func (p *Plugin) processInstallationUpdate(pluginInstall *Installation, cloudIns
 		return false, nil
 	}
 
+	if !cleanupDeleted {
+		return true, nil
+	}
+
 	// The installation was deleted on the cloud server so remove it from the KV
 	// store to sync state and notify the user.
 	p.API.LogWarn(fmt.Sprintf("Removing deleted installation %s with name %s from the KV store", pluginInstall.ID, pluginInstall.Name))
-	err = p.deleteInstallation(pluginInstall.ID)
-	if err != nil {
+	if err = p.deleteInstallation(pluginInstall.ID); err != nil {
 		return true, errors.Wrapf(err, "unable to delete installation %s in the KV store", pluginInstall.ID)
 	}
 

--- a/server/command_list_test.go
+++ b/server/command_list_test.go
@@ -25,7 +25,9 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 					Installation: &cloud.Installation{
 						ID:            "id1",
 						State:         cloud.InstallationStateStable,
+						License:       "secret-license",
 						MattermostEnv: cloud.EnvVarMap{"secret": cloud.EnvVar{Value: "supersecret"}},
+						PriorityEnv:   cloud.EnvVarMap{"priority": cloud.EnvVar{Value: "prioritysecret"}},
 					},
 				},
 				{
@@ -69,7 +71,9 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, len(pluginInstalls), len(installations))
 			assert.Equal(t, "id1", installations[0].ID)
+			assert.Equal(t, "secret-license", installations[0].License)
 			assert.NotNil(t, installations[0].MattermostEnv)
+			assert.NotNil(t, installations[0].PriorityEnv)
 			t.Log(installations[0].State)
 		})
 
@@ -78,7 +82,9 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, len(pluginInstalls), len(installations))
 			assert.Equal(t, "id1", installations[0].ID)
+			assert.Equal(t, "hidden", installations[0].License)
 			assert.Nil(t, installations[0].MattermostEnv)
+			assert.Nil(t, installations[0].PriorityEnv)
 		})
 	})
 
@@ -101,6 +107,74 @@ func TestGetUpdatedInstallsForUser(t *testing.T) {
 		assert.Contains(t, installations[2].Name, "installation-three")
 		assert.Contains(t, installations[2].Name, "DELETED")
 	})
+}
+
+func TestGetUpdatedInstallsForUserWithoutSensitiveDoesNotMutateRefreshSource(t *testing.T) {
+	cloudInstall := &cloud.InstallationDTO{Installation: &cloud.Installation{
+		ID:            "id1",
+		OwnerID:       "owner 1",
+		State:         cloud.InstallationStateStable,
+		License:       "secret-license",
+		MattermostEnv: cloud.EnvVarMap{"secret": cloud.EnvVar{Value: "supersecret"}},
+		PriorityEnv:   cloud.EnvVarMap{"priority": cloud.EnvVar{Value: "prioritysecret"}},
+	}}
+	plugin := Plugin{
+		cloudClient:  &MockClient{mockedCloudInstallationsDTO: []*cloud.InstallationDTO{cloudInstall}},
+		dockerClient: &MockedDockerClient{tagExists: true},
+	}
+	api := &plugintest.API{}
+	_, installationBytes, err := getFakePluginInstallations()
+	require.NoError(t, err)
+	api.On("KVGet", mock.AnythingOfType("string")).Return(installationBytes, nil)
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	api.On("LogWarn", mock.AnythingOfType("string")).Return(nil)
+	plugin.SetAPI(api)
+
+	withoutSensitive, err := plugin.getUpdatedInstallsForUserWithoutSensitive("owner 1")
+	require.NoError(t, err)
+	require.NotEmpty(t, withoutSensitive)
+	assert.Equal(t, "hidden", withoutSensitive[0].License)
+	assert.Nil(t, withoutSensitive[0].MattermostEnv)
+	assert.Nil(t, withoutSensitive[0].PriorityEnv)
+
+	withSensitive, err := plugin.getUpdatedInstallsForUserWithSensitive("owner 1")
+	require.NoError(t, err)
+	require.NotEmpty(t, withSensitive)
+	assert.Equal(t, "secret-license", withSensitive[0].License)
+	assert.Equal(t, "supersecret", withSensitive[0].MattermostEnv["secret"].Value)
+	assert.Equal(t, "prioritysecret", withSensitive[0].PriorityEnv["priority"].Value)
+}
+
+func TestGetUpdatedSharedInstallationsWithoutSensitiveDoesNotMutateRefreshSource(t *testing.T) {
+	plugin := Plugin{
+		cloudClient: &MockClient{overrideGetInstallationDTO: &cloud.InstallationDTO{Installation: &cloud.Installation{
+			ID:            "sharedid",
+			OwnerID:       "owner 1",
+			State:         cloud.InstallationStateStable,
+			License:       "shared-secret-license",
+			MattermostEnv: cloud.EnvVarMap{"sharedsecret": cloud.EnvVar{Value: "sharedsecretvalue"}},
+			PriorityEnv:   cloud.EnvVarMap{"sharedpriority": cloud.EnvVar{Value: "sharedpriorityvalue"}},
+		}}},
+		dockerClient: &MockedDockerClient{tagExists: true},
+	}
+	api := &plugintest.API{}
+	api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"sharedid\", \"OwnerID\": \"owner 1\", \"Name\": \"shared\", \"Shared\": true}]"), nil)
+	api.On("LogWarn", mock.AnythingOfType("string")).Return(nil)
+	plugin.SetAPI(api)
+
+	withoutSensitive, err := plugin.getUpdatedSharedInstallations(true)
+	require.NoError(t, err)
+	require.Len(t, withoutSensitive, 1)
+	assert.Equal(t, "hidden", withoutSensitive[0].License)
+	assert.Nil(t, withoutSensitive[0].MattermostEnv)
+	assert.Nil(t, withoutSensitive[0].PriorityEnv)
+
+	withSensitive, err := plugin.getUpdatedSharedInstallations(false)
+	require.NoError(t, err)
+	require.Len(t, withSensitive, 1)
+	assert.Equal(t, "shared-secret-license", withSensitive[0].License)
+	assert.Equal(t, "sharedsecretvalue", withSensitive[0].MattermostEnv["sharedsecret"].Value)
+	assert.Equal(t, "sharedpriorityvalue", withSensitive[0].PriorityEnv["sharedpriority"].Value)
 }
 
 func getFakePluginInstallations() ([]*Installation, []byte, error) {
@@ -178,8 +252,12 @@ func TestListCommand(t *testing.T) {
 			Installation: &cloud.Installation{
 				ID:      "someid",
 				OwnerID: "sharedid",
+				License: "license-secret",
 				MattermostEnv: cloud.EnvVarMap{
 					"testkey": cloud.EnvVar{Value: "testval"},
+				},
+				PriorityEnv: cloud.EnvVarMap{
+					"prioritykey": cloud.EnvVar{Value: "priorityval"},
 				},
 			},
 		}}
@@ -188,7 +266,37 @@ func TestListCommand(t *testing.T) {
 		require.Nil(t, err)
 		assert.False(t, isUserError)
 		assert.True(t, strings.Contains(resp.Text, "someid"))
+		assert.False(t, strings.Contains(resp.Text, "\"License\""))
+		assert.False(t, strings.Contains(resp.Text, "license-secret"))
+		assert.False(t, strings.Contains(resp.Text, "\"MattermostEnv\""))
 		assert.False(t, strings.Contains(resp.Text, "testkey"))
 		assert.False(t, strings.Contains(resp.Text, "testval"))
+		assert.False(t, strings.Contains(resp.Text, "\"PriorityEnv\""))
+		assert.False(t, strings.Contains(resp.Text, "prioritykey"))
+		assert.False(t, strings.Contains(resp.Text, "priorityval"))
 	})
+}
+
+func TestListCommandCleansUpDeletedInstallations(t *testing.T) {
+	plugin := Plugin{
+		cloudClient: &MockClient{
+			overrideGetInstallationDTO: &cloud.InstallationDTO{Installation: &cloud.Installation{
+				ID:      "deletedid",
+				OwnerID: "ownerid",
+				State:   cloud.InstallationStateDeleted,
+			}},
+		},
+		dockerClient: &MockedDockerClient{tagExists: true},
+	}
+	api := &plugintest.API{}
+	api.On("KVGet", mock.AnythingOfType("string")).Return([]byte("[{\"ID\": \"deletedid\", \"OwnerID\": \"ownerid\", \"Name\": \"deletedinstall\"}]"), nil)
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil).Once()
+	api.On("LogWarn", mock.AnythingOfType("string")).Return(nil)
+	plugin.SetAPI(api)
+
+	resp, isUserError, err := plugin.runListCommand([]string{}, &model.CommandArgs{UserId: "ownerid"})
+	require.NoError(t, err)
+	assert.False(t, isUserError)
+	assert.Contains(t, resp.Text, "deletedinstall [ DELETED ]")
+	api.AssertExpectations(t)
 }

--- a/server/command_restart.go
+++ b/server/command_restart.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
-	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
@@ -34,30 +34,15 @@ func (p *Plugin) runRestartCommand(args []string, extra *model.CommandArgs) (*mo
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatableInstallationsForUser(extra.UserId, includeShared)
-	if err != nil {
-		return nil, false, err
+	scope := InstallationScopeMine
+	if includeShared {
+		scope = InstallationScopeUpdatable
 	}
-
-	var installToRestart *Installation
-	for _, install := range installs {
-		if standardizeName(install.Name) == name {
-			installToRestart = install
-			break
+	_, err = p.restartInstallationForUser(extra.UserId, InstallationRef{Name: name}, scope)
+	if err != nil {
+		if strings.Contains(err.Error(), "no installation with the name") {
+			return nil, true, err
 		}
-	}
-
-	if installToRestart == nil {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-
-	// We can force a restart by changing any environment variable, so we will
-	// set something arbitrary with the current date and time.
-	patch := &cloud.PatchInstallationRequest{MattermostEnv: cloud.EnvVarMap{
-		"CLOUD_PLUGIN_RESTART": cloud.EnvVar{Value: cloud.DateTimeStringFromMillis(cloud.GetMillis())},
-	}}
-	_, err = p.cloudClient.UpdateInstallation(installToRestart.ID, patch)
-	if err != nil {
 		return nil, false, err
 	}
 

--- a/server/command_share.go
+++ b/server/command_share.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
@@ -47,26 +48,11 @@ func (p *Plugin) runShareInstallationCommand(args []string, extra *model.Command
 		return nil, true, err
 	}
 
-	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	_, err = p.setInstallationSharingForUser(extra.UserId, InstallationRef{Name: name}, true, config.AllowUpdates)
 	if err != nil {
-		return nil, true, err
-	}
-	var installationToShare *Installation
-	for _, installation := range installations {
-		if installation.OwnerID == extra.UserId && installation.Name == name {
-			installationToShare = installation
-			break
+		if strings.Contains(err.Error(), "no installation with the name") {
+			return nil, true, err
 		}
-	}
-
-	if installationToShare == nil {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-
-	installationToShare.Shared = true
-	installationToShare.AllowSharedUpdates = config.AllowUpdates
-	err = p.updateInstallation(installationToShare)
-	if err != nil {
 		return getCommandResponse(model.CommandResponseTypeEphemeral, err.Error(), extra), false, err
 	}
 
@@ -84,26 +70,11 @@ func (p *Plugin) runUnshareInstallationCommand(args []string, extra *model.Comma
 
 	name := standardizeName(args[0])
 
-	installations, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	_, err := p.setInstallationSharingForUser(extra.UserId, InstallationRef{Name: name}, false, false)
 	if err != nil {
-		return nil, true, err
-	}
-	var installationToShare *Installation
-	for _, installation := range installations {
-		if installation.OwnerID == extra.UserId && installation.Name == name {
-			installationToShare = installation
-			break
+		if strings.Contains(err.Error(), "no installation with the name") {
+			return nil, true, err
 		}
-	}
-
-	if installationToShare == nil {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-
-	installationToShare.Shared = false
-	installationToShare.AllowSharedUpdates = false
-	err = p.updateInstallation(installationToShare)
-	if err != nil {
 		return getCommandResponse(model.CommandResponseTypeEphemeral, err.Error(), extra), false, err
 	}
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -25,9 +25,24 @@ type MockClient struct {
 	// Stores latest CreateInstallationRequest passed to mock
 	creationRequest *cloud.CreateInstallationRequest
 	// Stores latest PatchInstallationRequest passed to mock
-	patchRequest *cloud.PatchInstallationRequest
+	patchRequest             *cloud.PatchInstallationRequest
+	patchInstallationID      string
+	deletedInstallationID    string
+	lockedInstallationID     string
+	unlockedInstallationID   string
+	hibernatedInstallationID string
+	wokenInstallationID      string
 
-	err error
+	createErr    error
+	updateErr    error
+	deleteErr    error
+	lockErr      error
+	unlockErr    error
+	hibernateErr error
+	wakeErr      error
+	listErr      error
+	clusterErr   error
+	err          error
 }
 
 func (mc *MockClient) ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error) {
@@ -35,11 +50,17 @@ func (mc *MockClient) ExecClusterInstallationCLI(clusterInstallationID, command 
 }
 
 func (mc *MockClient) GetClusters(request *cloud.GetClustersRequest) ([]*cloud.ClusterDTO, error) {
+	if mc.clusterErr != nil {
+		return nil, mc.clusterErr
+	}
 	return mc.mockedCloudClustersDTO, mc.err
 }
 
 func (mc *MockClient) CreateInstallation(request *cloud.CreateInstallationRequest) (*cloud.InstallationDTO, error) {
 	mc.creationRequest = request
+	if mc.createErr != nil {
+		return nil, mc.createErr
+	}
 	return &cloud.InstallationDTO{Installation: &cloud.Installation{ID: "someid"}}, nil
 }
 
@@ -66,31 +87,58 @@ func (mc *MockClient) GetInstallationByDNS(DNS string, request *cloud.GetInstall
 }
 
 func (mc *MockClient) GetInstallations(request *cloud.GetInstallationsRequest) ([]*cloud.InstallationDTO, error) {
+	if mc.listErr != nil {
+		return nil, mc.listErr
+	}
 	return mc.mockedCloudInstallationsDTO, mc.err
 }
 
 func (mc *MockClient) UpdateInstallation(installationID string, request *cloud.PatchInstallationRequest) (*cloud.InstallationDTO, error) {
+	mc.patchInstallationID = installationID
 	mc.patchRequest = request
+	if mc.updateErr != nil {
+		return nil, mc.updateErr
+	}
 	return &cloud.InstallationDTO{Installation: &cloud.Installation{ID: "someid", OwnerID: "joramid"}}, nil
 }
 
 func (mc *MockClient) HibernateInstallation(installationID string) (*cloud.InstallationDTO, error) {
+	mc.hibernatedInstallationID = installationID
+	if mc.hibernateErr != nil {
+		return nil, mc.hibernateErr
+	}
 	return &cloud.InstallationDTO{Installation: &cloud.Installation{ID: "someid", OwnerID: "joramid"}}, nil
 }
 
 func (mc *MockClient) WakeupInstallation(installationID string, request *cloud.PatchInstallationRequest) (*cloud.InstallationDTO, error) {
+	mc.wokenInstallationID = installationID
+	if mc.wakeErr != nil {
+		return nil, mc.wakeErr
+	}
 	return &cloud.InstallationDTO{Installation: &cloud.Installation{ID: "someid", OwnerID: "joramid"}}, nil
 }
 
 func (mc *MockClient) LockDeletionLockForInstallation(installationID string) error {
+	mc.lockedInstallationID = installationID
+	if mc.lockErr != nil {
+		return mc.lockErr
+	}
 	return nil
 }
 
 func (mc *MockClient) UnlockDeletionLockForInstallation(installationID string) error {
+	mc.unlockedInstallationID = installationID
+	if mc.unlockErr != nil {
+		return mc.unlockErr
+	}
 	return nil
 }
 
 func (mc *MockClient) DeleteInstallation(installationID string) error {
+	mc.deletedInstallationID = installationID
+	if mc.deleteErr != nil {
+		return mc.deleteErr
+	}
 	return nil
 }
 

--- a/server/command_update.go
+++ b/server/command_update.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
@@ -23,80 +22,6 @@ func getUpdateFlagSet() *flag.FlagSet {
 	return updateFlagSet
 }
 
-func buildPatchInstallationRequestFromArgs(args []string) (*cloud.PatchInstallationRequest, bool, error) {
-	updateFlagSet := getUpdateFlagSet()
-	err := updateFlagSet.Parse(args)
-	if err != nil {
-		return nil, false, err
-	}
-
-	version, err := updateFlagSet.GetString("version")
-	if err != nil {
-		return nil, false, err
-	}
-	license, err := updateFlagSet.GetString("license")
-	if err != nil {
-		return nil, false, err
-	}
-	size, err := updateFlagSet.GetString("size")
-	if err != nil {
-		return nil, false, err
-	}
-	if size != "" && !Contains(validInstallationSizes, size) {
-		return nil, false, fmt.Errorf("Invalid size: %s", size)
-	}
-
-	image, err := updateFlagSet.GetString("image")
-	if err != nil {
-		return nil, false, err
-	}
-	envVars, err := updateFlagSet.GetStringSlice("env")
-	if err != nil {
-		return nil, false, err
-	}
-	envClear, err := updateFlagSet.GetStringSlice("clear-env")
-	if err != nil {
-		return nil, false, err
-	}
-	if version == "" && license == "" && size == "" && image == "" && len(envVars) == 0 && len(envClear) == 0 {
-		return nil, false, errors.New("must specify at least one option: version, license, image, size, env, clear-env")
-	}
-	if license != "" && !validLicenseOption(license) {
-		return nil, false, errors.Errorf("invalid license option %s, valid options are %s", license, strings.Join(validLicenseOptions, ", "))
-	}
-	if image != "" && !validImageName(image) {
-		return nil, false, errors.Errorf("invalid image name %s, valid options are %s", image, strings.Join(dockerRepoWhitelist, ", "))
-	}
-
-	envVarMap, err := parseEnvVarInput(envVars, envClear)
-	if err != nil {
-		return nil, false, err
-	}
-
-	request := &cloud.PatchInstallationRequest{
-		PriorityEnv: envVarMap,
-	}
-	if version != "" {
-		request.Version = &version
-	}
-	if license != "" {
-		request.License = &license
-	}
-	if size != "" {
-		request.Size = &size
-	}
-	if image != "" {
-		request.Image = &image
-	}
-
-	shared, err := updateFlagSet.GetBool("shared-installation")
-	if err != nil {
-		return nil, false, err
-	}
-
-	return request, shared, nil
-}
-
 // runUpdateCommand requests an update and returns the response, an
 // error, and a boolean set to true if a non-nil error is returned due
 // to user error, and false if the error was caused by something else.
@@ -107,71 +32,21 @@ func (p *Plugin) runUpdateCommand(args []string, extra *model.CommandArgs) (*mod
 
 	name := standardizeName(args[0])
 
-	request, shared, err := buildPatchInstallationRequestFromArgs(args)
+	input, shared, err := updateInstallationInputFromArgs(args)
 	if err != nil {
 		return nil, true, err
 	}
-	var installToUpdate *Installation
 
-	installs, err := p.getUpdatableInstallationsForUser(extra.UserId, shared)
+	scope := InstallationScopeMine
+	if shared {
+		scope = InstallationScopeUpdatable
+	}
+	result, err := p.updateInstallationForUser(extra.UserId, InstallationRef{Name: name}, input, scope)
 	if err != nil {
+		if isUpdateUserError(err) {
+			return nil, true, err
+		}
 		return nil, false, err
-	}
-
-	// Find the installation by name
-	for _, install := range installs {
-		if install.Name == name {
-			installToUpdate = install
-			break
-		}
-	}
-
-	if installToUpdate == nil {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-
-	if request.Version != nil || request.Image != nil {
-		dockerTag := installToUpdate.Version
-		dockerRepository := installToUpdate.Image
-
-		if request.Version != nil {
-			dockerTag = *request.Version
-		}
-		if request.Image != nil {
-			dockerRepository = *request.Image
-		}
-		// Check that new version exists.
-		var exists bool
-		exists, err = p.dockerClient.ValidTag(dockerTag, dockerRepository)
-		if err != nil {
-			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", dockerRepository, dockerTag).Error())
-		}
-		if !exists {
-			return nil, true, errors.Errorf("%s is not a valid docker tag for repository %s", dockerTag, dockerRepository)
-		}
-		var digest string
-		digest, err = p.dockerClient.GetDigestForTag(dockerTag, dockerRepository)
-		if err != nil {
-			return nil, false, errors.Wrapf(err, "failed to find a manifest digest for version %s", dockerTag)
-		}
-		installToUpdate.Tag = dockerTag
-		request.Version = &digest
-	}
-
-	if request.License != nil {
-		// Translate the license option.
-		licenseValue := p.getLicenseValue(*request.License)
-		request.License = &licenseValue
-	}
-
-	_, err = p.cloudClient.UpdateInstallation(installToUpdate.ID, request)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "failed to update installation")
-	}
-
-	err = p.updateInstallation(installToUpdate)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "failed to store updated installation metadata")
 	}
 
 	if shared {
@@ -179,14 +54,78 @@ func (p *Plugin) runUpdateCommand(args []string, extra *model.CommandArgs) (*mod
 		// occurred. Only log an error if there is an issue getting the update.
 		// requester details, but still try to send the message.
 		username := "A user"
-		updateRquester, err := p.API.GetUser(extra.UserId)
+		updateRequester, err := p.API.GetUser(extra.UserId)
 		if err != nil {
 			p.API.LogError(errors.Wrap(err, "failed to get update request user details").Error())
 		} else {
-			username = fmt.Sprintf("@%s", updateRquester.Username)
+			username = fmt.Sprintf("@%s", updateRequester.Username)
 		}
-		p.PostBotDM(installToUpdate.OwnerID, fmt.Sprintf("%s has updated an installation you have shared. The following command was run: `%s`", username, extra.Command))
+		p.PostBotDM(result.Installation.OwnerID, fmt.Sprintf("%s has updated an installation you have shared. The following command was run: `%s`", username, extra.Command))
 	}
 
 	return getCommandResponse(model.CommandResponseTypeEphemeral, fmt.Sprintf("Update of installation %s has begun. You will receive a notification when it is ready. Use /cloud list to check on the status of your installations.", name), extra), false, nil
+}
+
+func updateInstallationInputFromArgs(args []string) (UpdateInstallationInput, bool, error) {
+	updateFlagSet := getUpdateFlagSet()
+	if err := updateFlagSet.Parse(args); err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+
+	input := UpdateInstallationInput{}
+	var err error
+	input.Version, err = updateFlagSet.GetString("version")
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+	input.License, err = updateFlagSet.GetString("license")
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+	input.Size, err = updateFlagSet.GetString("size")
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+	input.Image, err = updateFlagSet.GetString("image")
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+
+	envVars, err := updateFlagSet.GetStringSlice("env")
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+	input.ClearEnv, err = updateFlagSet.GetStringSlice("clear-env")
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+	envVarMap, err := parseEnvVarInput(envVars, input.ClearEnv)
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+	input.SetEnv = map[string]string{}
+	for key, env := range envVarMap {
+		if env.HasValue() {
+			input.SetEnv[key] = env.Value
+		}
+	}
+
+	shared, err := updateFlagSet.GetBool("shared-installation")
+	if err != nil {
+		return UpdateInstallationInput{}, false, err
+	}
+
+	return input, shared, nil
+}
+
+func isUpdateUserError(err error) bool {
+	errText := err.Error()
+	return strings.Contains(errText, "must specify at least one option") ||
+		strings.Contains(errText, "Invalid size:") ||
+		strings.Contains(errText, "invalid license option") ||
+		strings.Contains(errText, "invalid image name") ||
+		strings.Contains(errText, "valid env format") ||
+		strings.Contains(errText, "defined more than once") ||
+		strings.Contains(errText, "no installation with the name") ||
+		strings.Contains(errText, "is not a valid docker tag")
 }

--- a/server/command_wakeup.go
+++ b/server/command_wakeup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	cloud "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -16,28 +17,12 @@ func (p *Plugin) runWakeUpCommand(args []string, extra *model.CommandArgs) (*mod
 
 	name := standardizeName(args[0])
 
-	installs, err := p.getUpdatedInstallsForUserWithoutSensitive(extra.UserId)
+	_, err := p.wakeInstallationForUser(extra.UserId, InstallationRef{Name: name})
 	if err != nil {
-		return nil, false, err
-	}
-
-	var installToWakeUp *Installation
-	for _, install := range installs {
-		if install.OwnerID == extra.UserId && install.Name == name {
-			installToWakeUp = install
-			break
+		if strings.Contains(err.Error(), "no installation with the name") ||
+			strings.Contains(err.Error(), fmt.Sprintf("must be %s to wake up", cloud.InstallationStateHibernating)) {
+			return nil, true, err
 		}
-	}
-
-	if installToWakeUp == nil {
-		return nil, true, errors.Errorf("no installation with the name %s found", name)
-	}
-	if installToWakeUp.State != cloud.InstallationStateHibernating {
-		return nil, true, errors.Errorf("installation state is currently %s and must be %s to wake up", installToWakeUp.State, cloud.InstallationStateHibernating)
-	}
-
-	_, err = p.cloudClient.WakeupInstallation(installToWakeUp.ID, &cloud.PatchInstallationRequest{})
-	if err != nil {
 		return nil, false, err
 	}
 

--- a/server/docker_test.go
+++ b/server/docker_test.go
@@ -1,13 +1,26 @@
 package main
 
 type MockedDockerClient struct {
-	tagExists bool
+	tagExists      bool
+	digest         string
+	validTagCalls  []dockerClientCall
+	getDigestCalls []dockerClientCall
+}
+
+type dockerClientCall struct {
+	tag        string
+	repository string
 }
 
 func (mc *MockedDockerClient) ValidTag(desiredTag, repository string) (bool, error) {
+	mc.validTagCalls = append(mc.validTagCalls, dockerClientCall{tag: desiredTag, repository: repository})
 	return mc.tagExists, nil
 }
 
 func (mc *MockedDockerClient) GetDigestForTag(desiredTag, repository string) (string, error) {
+	mc.getDigestCalls = append(mc.getDigestCalls, dockerClientCall{tag: desiredTag, repository: repository})
+	if mc.digest != "" {
+		return mc.digest, nil
+	}
 	return desiredTag, nil
 }

--- a/server/installation.go
+++ b/server/installation.go
@@ -40,6 +40,7 @@ func (i *Installation) ToPrettyJSON() string {
 func (i *Installation) HideSensitiveFields() {
 	i.License = "hidden"
 	i.MattermostEnv = nil
+	i.PriorityEnv = nil
 }
 
 func (p *Plugin) storeInstallation(install *Installation) error {
@@ -143,7 +144,11 @@ func (p *Plugin) deleteInstallation(installationID string) error {
 		for index, install := range installs {
 			if install.ID == installationID {
 				indexToDelete = index
+				break
 			}
+		}
+		if indexToDelete == -1 {
+			return errors.New("installation does not exist")
 		}
 
 		installs = append(installs[:indexToDelete], installs[indexToDelete+1:]...)
@@ -232,24 +237,6 @@ func (p *Plugin) getInstallationsForUser(userID string) ([]*Installation, error)
 	return installsForUser, nil
 }
 
-// getUpdatableInstallationsForUser returns installations the given user can update. Unless
-// includeShared is set, this is equivalent to calling getInstallationsForUser.
-func (p *Plugin) getUpdatableInstallationsForUser(userID string, includeShared bool) ([]*Installation, error) {
-	installs, _, err := p.getInstallations()
-	if err != nil {
-		return nil, err
-	}
-
-	updatableInstallsForUser := []*Installation{}
-	for _, install := range installs {
-		if install.OwnerID == userID || (includeShared && install.Shared && install.AllowSharedUpdates) {
-			updatableInstallsForUser = append(updatableInstallsForUser, install)
-		}
-	}
-
-	return updatableInstallsForUser, nil
-}
-
 func (p *Plugin) getUpdatedSharedInstallations(hideSensitive bool) ([]*Installation, error) {
 	sharedInstalls, err := p.getSharedInstallations()
 	if err != nil {
@@ -268,9 +255,10 @@ func (p *Plugin) getUpdatedSharedInstallations(hideSensitive bool) ([]*Installat
 			return nil, fmt.Errorf("could not find installation %s", install.ID)
 		}
 		install.InstallationDTO = *updatedInstall
-		if hideSensitive {
-			install.HideSensitiveFields()
-		}
+	}
+
+	if hideSensitive {
+		return sanitizeInstallationCopies(sharedInstalls), nil
 	}
 
 	return sharedInstalls, nil

--- a/server/installation_service.go
+++ b/server/installation_service.go
@@ -674,6 +674,9 @@ func (p *Plugin) buildUpdateInstallationRequest(install *Installation, input Upd
 	sort.Strings(clearEnvKeys)
 	if len(input.SetEnv) > 0 || len(input.ClearEnv) > 0 {
 		request.PriorityEnv = envMapFromInput(input.SetEnv)
+		if request.PriorityEnv == nil {
+			request.PriorityEnv = make(cloud.EnvVarMap, len(input.ClearEnv))
+		}
 		for _, key := range input.ClearEnv {
 			request.PriorityEnv[key] = cloud.EnvVar{}
 		}

--- a/server/installation_service.go
+++ b/server/installation_service.go
@@ -1,0 +1,819 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+type InstallationScope string
+
+const (
+	InstallationScopeMine      InstallationScope = "mine"
+	InstallationScopeShared    InstallationScope = "shared"
+	InstallationScopeUpdatable InstallationScope = "updatable"
+)
+
+type InstallationRef struct {
+	ID   string
+	Name string
+}
+
+type ListInstallationsInput struct {
+	Scope          InstallationScope
+	Refresh        bool
+	IncludeLogURLs bool
+}
+
+type CreateInstallationInput struct {
+	Name      string
+	Version   string
+	Size      string
+	License   string
+	Affinity  string
+	Database  string
+	Filestore string
+	Image     string
+	TestData  bool
+	Env       map[string]string
+}
+
+type UpdateInstallationInput struct {
+	Version  string
+	License  string
+	Size     string
+	Image    string
+	SetEnv   map[string]string
+	ClearEnv []string
+}
+
+type InstallationSummary struct {
+	ID                  string `json:"id"`
+	Name                string `json:"name"`
+	DNS                 string `json:"dns,omitempty"`
+	State               string `json:"state"`
+	OwnerID             string `json:"owner_id"`
+	Version             string `json:"version"`
+	VersionTag          string `json:"version_tag,omitempty"`
+	Image               string `json:"image,omitempty"`
+	Size                string `json:"size,omitempty"`
+	Database            string `json:"database,omitempty"`
+	Filestore           string `json:"filestore,omitempty"`
+	Affinity            string `json:"affinity,omitempty"`
+	TestData            bool   `json:"test_data"`
+	Shared              bool   `json:"shared"`
+	AllowSharedUpdates  bool   `json:"allow_shared_updates"`
+	DeletionLocked      bool   `json:"deletion_locked"`
+	CreateAt            int64  `json:"create_at,omitempty"`
+	ServiceEnvironment  string `json:"service_environment,omitempty"`
+	InstallationLogsURL string `json:"installation_logs_url,omitempty"`
+	ProvisionerLogsURL  string `json:"provisioner_logs_url,omitempty"`
+}
+
+type InstallationActionResult struct {
+	Installation   InstallationSummary `json:"installation"`
+	Status         string              `json:"status"`
+	ChangedFields  []string            `json:"changed_fields,omitempty"`
+	ChangedEnvKeys []string            `json:"changed_env_keys,omitempty"`
+	ClearedEnvKeys []string            `json:"cleared_env_keys,omitempty"`
+	Message        string              `json:"message,omitempty"`
+}
+
+// sanitizeInstallationCopy returns a copy of install with sensitive fields
+// hidden. HideSensitiveFields only reassigns fields, so a shallow copy of the
+// outer wrapper plus the embedded *cloud.Installation is enough to keep the
+// caller's pointer untouched.
+func sanitizeInstallationCopy(install *Installation) *Installation {
+	if install == nil {
+		return nil
+	}
+
+	sanitized := *install
+	if install.Installation != nil {
+		innerCopy := *install.Installation
+		sanitized.Installation = &innerCopy
+	}
+	sanitized.HideSensitiveFields()
+	return &sanitized
+}
+
+func sanitizeInstallationCopies(installs []*Installation) []*Installation {
+	sanitized := make([]*Installation, 0, len(installs))
+	for _, install := range installs {
+		if sanitizedInstall := sanitizeInstallationCopy(install); sanitizedInstall != nil {
+			sanitized = append(sanitized, sanitizedInstall)
+		}
+	}
+	return sanitized
+}
+
+func installationSummary(install *Installation, includeLogURLs bool) (InstallationSummary, error) {
+	if install == nil {
+		return InstallationSummary{}, errors.New("installation must not be nil")
+	}
+
+	summary := InstallationSummary{
+		Name:               install.Name,
+		TestData:           install.TestData,
+		Shared:             install.Shared,
+		AllowSharedUpdates: install.AllowSharedUpdates,
+		ServiceEnvironment: getInstallationServiceEnvironment(install),
+	}
+
+	if install.Installation != nil {
+		summary.ID = install.ID
+		summary.State = install.State
+		summary.OwnerID = install.OwnerID
+		summary.Version = install.Version
+		summary.VersionTag = install.Tag
+		summary.Image = install.Image
+		summary.Size = install.Size
+		summary.Database = install.Database
+		summary.Filestore = install.Filestore
+		summary.Affinity = install.Affinity
+		summary.DeletionLocked = install.DeletionLocked
+		summary.CreateAt = install.CreateAt
+	}
+
+	if len(install.DNSRecords) > 0 && install.DNSRecords[0] != nil {
+		summary.DNS = install.DNSRecords[0].DomainName
+	}
+
+	if includeLogURLs && summary.ID != "" {
+		logURLData := struct {
+			ID string
+		}{ID: summary.ID}
+
+		installationLogsURL, err := getStringFromTemplate(installationLogsURLTmpl, logURLData)
+		if err != nil {
+			return InstallationSummary{}, err
+		}
+		provisionerLogsURL, err := getStringFromTemplate(provisionerLogsURLTmpl, logURLData)
+		if err != nil {
+			return InstallationSummary{}, err
+		}
+		summary.InstallationLogsURL = installationLogsURL
+		summary.ProvisionerLogsURL = provisionerLogsURL
+	}
+
+	return summary, nil
+}
+
+func (p *Plugin) findInstallationForUser(userID string, ref InstallationRef, scope InstallationScope) (*Installation, error) {
+	if err := ref.validate(); err != nil {
+		return nil, err
+	}
+
+	installs, _, err := p.getInstallations()
+	if err != nil {
+		return nil, err
+	}
+
+	return findInstallationInSlice(userID, ref, defaultInstallationScope(scope), installs)
+}
+
+func (p *Plugin) listInstallationsForUser(userID string, input ListInstallationsInput) ([]*Installation, error) {
+	scope := defaultInstallationScope(input.Scope)
+	if err := validateInstallationScope(scope); err != nil {
+		return nil, err
+	}
+
+	if !input.Refresh {
+		installs, _, err := p.getInstallations()
+		if err != nil {
+			return nil, err
+		}
+		return filterInstallationsForScope(userID, scope, installs), nil
+	}
+
+	switch scope {
+	case InstallationScopeMine:
+		return p.getRefreshedInstallsForUser(userID, false)
+	case InstallationScopeShared:
+		return p.getUpdatedSharedInstallations(false)
+	case InstallationScopeUpdatable:
+		ownedInstalls, err := p.getRefreshedInstallsForUser(userID, false)
+		if err != nil {
+			return nil, err
+		}
+		sharedInstalls, err := p.getUpdatedSharedInstallations(false)
+		if err != nil {
+			return nil, err
+		}
+		return dedupeInstallations(append(ownedInstalls, filterInstallationsForScope(userID, InstallationScopeUpdatable, sharedInstalls)...)), nil
+	default:
+		return nil, errors.Errorf("unknown installation scope %s", scope)
+	}
+}
+
+func (p *Plugin) createInstallationForUser(userID string, input CreateInstallationInput) (*Installation, error) {
+	install, err := p.buildCreateInstallation(userID, input)
+	if err != nil {
+		return nil, err
+	}
+
+	validTag, err := p.dockerClient.ValidTag(install.Version, install.Image)
+	if err != nil {
+		p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", install.Image, install.Version).Error())
+	}
+	if !validTag {
+		return nil, errors.Errorf("%s is not a valid docker tag for repository %s", install.Version, install.Image)
+	}
+
+	digest, err := p.dockerClient.GetDigestForTag(install.Version, install.Image)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to find a manifest digest for version %s", install.Version)
+	}
+
+	install.Version = digest
+	config := p.getConfiguration()
+	req := &cloud.CreateInstallationRequest{
+		Name:        install.Name,
+		OwnerID:     userID,
+		GroupID:     config.GroupID,
+		Affinity:    install.Affinity,
+		DNSNames:    []string{fmt.Sprintf("%s.%s", install.Name, config.InstallationDNS)},
+		Database:    install.Database,
+		Filestore:   install.Filestore,
+		PriorityEnv: install.PriorityEnv,
+		License:     p.getLicenseValue(install.License),
+		Size:        install.Size,
+		Version:     install.Version,
+		Image:       install.Image,
+		Annotations: []string{defaultMultiTenantAnnotation},
+	}
+
+	if config.ScheduledDeletionHours != "" && config.ScheduledDeletionHours != "0" {
+		hours, hoursErr := strconv.Atoi(config.ScheduledDeletionHours)
+		if hoursErr == nil && hours > 0 {
+			req.ScheduledDeletionTime = time.Now().Add(time.Duration(hours) * time.Hour).UnixMilli()
+		}
+	}
+
+	cloudInstallation, err := p.cloudClient.CreateInstallation(req)
+	if err != nil {
+		if strings.Contains(err.Error(), "409") {
+			return nil, errors.Errorf("Installation name %s already exists. **NOTE**: installation names are reserved for 24 hours after deletion in order to support restoration. Please try a new name, wait 24 hours, or contact the Cloud Platform team for support.", install.Name)
+		}
+		return nil, errors.Wrap(err, "failed to create installation")
+	}
+
+	install.Installation = cloudInstallation.Installation
+	if err = p.storeInstallation(install); err != nil {
+		return nil, err
+	}
+
+	return install, nil
+}
+
+func (p *Plugin) updateInstallationForUser(userID string, ref InstallationRef, input UpdateInstallationInput, scope InstallationScope) (InstallationActionResult, error) {
+	scope = defaultInstallationScope(scope)
+	if scope == InstallationScopeShared {
+		return InstallationActionResult{}, errors.New("shared scope is read-only for updates")
+	}
+
+	installToUpdate, err := p.findInstallationForUser(userID, ref, scope)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	request, changedFields, setEnvKeys, clearEnvKeys, requestedTag, err := p.buildUpdateInstallationRequest(installToUpdate, input)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	if _, err = p.cloudClient.UpdateInstallation(installToUpdate.ID, request); err != nil {
+		return InstallationActionResult{}, errors.Wrap(err, "failed to update installation")
+	}
+
+	if requestedTag != "" {
+		installToUpdate.Tag = requestedTag
+	}
+	if input.Image != "" {
+		installToUpdate.Image = input.Image
+	}
+	if input.Size != "" {
+		installToUpdate.Size = input.Size
+	}
+
+	if err = p.updateInstallation(installToUpdate); err != nil {
+		return InstallationActionResult{}, errors.Wrap(err, "failed to store updated installation metadata")
+	}
+
+	summary, err := installationSummary(installToUpdate, false)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	return InstallationActionResult{
+		Installation:   summary,
+		Status:         "update_requested",
+		ChangedFields:  changedFields,
+		ChangedEnvKeys: setEnvKeys,
+		ClearedEnvKeys: clearEnvKeys,
+	}, nil
+}
+
+func (p *Plugin) restartInstallationForUser(userID string, ref InstallationRef, scope InstallationScope) (InstallationActionResult, error) {
+	scope = defaultInstallationScope(scope)
+	if scope == InstallationScopeShared {
+		return InstallationActionResult{}, errors.New("shared scope is read-only for restarts")
+	}
+
+	installToRestart, err := p.findInstallationForUser(userID, ref, scope)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	patch := &cloud.PatchInstallationRequest{MattermostEnv: cloud.EnvVarMap{
+		"CLOUD_PLUGIN_RESTART": cloud.EnvVar{Value: cloud.DateTimeStringFromMillis(cloud.GetMillis())},
+	}}
+	if _, err = p.cloudClient.UpdateInstallation(installToRestart.ID, patch); err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	summary, err := installationSummary(installToRestart, false)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	return InstallationActionResult{
+		Installation:   summary,
+		Status:         "restart_requested",
+		ChangedEnvKeys: []string{"CLOUD_PLUGIN_RESTART"},
+	}, nil
+}
+
+func (p *Plugin) hibernateInstallationForUser(userID string, ref InstallationRef) (InstallationActionResult, error) {
+	installToHibernate, err := p.findRefInRefreshedList(userID, ref, InstallationScopeMine)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	if installToHibernate.State != cloud.InstallationStateStable {
+		return InstallationActionResult{}, errors.Errorf("installation state is currently %s and must be %s to hibernate", installToHibernate.State, cloud.InstallationStateStable)
+	}
+
+	if _, err = p.cloudClient.HibernateInstallation(installToHibernate.ID); err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	summary, err := installationSummary(installToHibernate, false)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	return InstallationActionResult{Installation: summary, Status: "hibernate_requested"}, nil
+}
+
+func (p *Plugin) wakeInstallationForUser(userID string, ref InstallationRef) (InstallationActionResult, error) {
+	installToWake, err := p.findRefInRefreshedList(userID, ref, InstallationScopeMine)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	if installToWake.State != cloud.InstallationStateHibernating {
+		return InstallationActionResult{}, errors.Errorf("installation state is currently %s and must be %s to wake up", installToWake.State, cloud.InstallationStateHibernating)
+	}
+
+	if _, err = p.cloudClient.WakeupInstallation(installToWake.ID, &cloud.PatchInstallationRequest{}); err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	summary, err := installationSummary(installToWake, false)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	return InstallationActionResult{Installation: summary, Status: "wake_requested"}, nil
+}
+
+func (p *Plugin) setInstallationSharingForUser(userID string, ref InstallationRef, shared bool, allowUpdates bool) (InstallationActionResult, error) {
+	install, err := p.findRefInRefreshedList(userID, ref, InstallationScopeMine)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	install.Shared = shared
+	install.AllowSharedUpdates = allowUpdates
+	if !shared {
+		install.AllowSharedUpdates = false
+	}
+
+	if err = p.updateInstallation(install); err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	summary, err := installationSummary(install, false)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	return InstallationActionResult{
+		Installation:  summary,
+		Status:        "sharing_updated",
+		ChangedFields: []string{"shared", "allow_shared_updates"},
+	}, nil
+}
+
+func (p *Plugin) setDeletionLockForUser(userID string, ref InstallationRef, locked bool) (InstallationActionResult, error) {
+	if ref.ID == "" && ref.Name == "" {
+		return InstallationActionResult{}, errors.New("must provide an installation ID or name")
+	}
+
+	installs, err := p.listInstallationsForUser(userID, ListInstallationsInput{Scope: InstallationScopeMine, Refresh: true})
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	if len(installs) == 0 {
+		return InstallationActionResult{}, errors.New("no installations found for the given User ID")
+	}
+
+	ref.Name = standardizeName(ref.Name)
+	var target *Installation
+	lockedCount := 0
+	for _, install := range installs {
+		if install.OwnerID != userID {
+			continue
+		}
+		if install.DeletionLocked {
+			lockedCount++
+		}
+		if ref.matches(install) {
+			target = install
+		}
+	}
+
+	if target == nil {
+		if locked {
+			return InstallationActionResult{}, errors.New("installation to be locked not found")
+		}
+		return InstallationActionResult{}, errors.New("installation to be unlocked not found")
+	}
+
+	if locked {
+		maxLockedInstallations, limitErr := strconv.Atoi(p.getConfiguration().DeletionLockInstallationsAllowedPerPerson)
+		if limitErr != nil {
+			return InstallationActionResult{}, errors.New("invalid value for DeletionLockInstallationsAllowedPerPerson")
+		}
+		if !target.DeletionLocked && maxLockedInstallations <= lockedCount {
+			return InstallationActionResult{}, fmt.Errorf("you may only have at most %d installations locked for deletion at a time", maxLockedInstallations)
+		}
+		if err = p.cloudClient.LockDeletionLockForInstallation(target.ID); err != nil {
+			return InstallationActionResult{}, err
+		}
+		target.DeletionLocked = true
+	} else {
+		if err = p.cloudClient.UnlockDeletionLockForInstallation(target.ID); err != nil {
+			return InstallationActionResult{}, err
+		}
+		target.DeletionLocked = false
+	}
+
+	if err = p.updateInstallation(target); err != nil {
+		return InstallationActionResult{}, errors.Wrap(err, "failed to persist deletion lock state")
+	}
+
+	summary, err := installationSummary(target, false)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+	return InstallationActionResult{
+		Installation:  summary,
+		Status:        "deletion_lock_updated",
+		ChangedFields: []string{"deletion_locked"},
+	}, nil
+}
+
+func (p *Plugin) deleteInstallationForUser(userID string, ref InstallationRef, confirmName string) (InstallationActionResult, error) {
+	installToDelete, err := p.findInstallationForUser(userID, ref, InstallationScopeMine)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	if standardizeName(confirmName) != standardizeName(installToDelete.Name) {
+		return InstallationActionResult{}, errors.Errorf("confirmation name %s does not match installation name %s", confirmName, installToDelete.Name)
+	}
+
+	summary, err := installationSummary(installToDelete, false)
+	if err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	if err = p.cloudClient.DeleteInstallation(installToDelete.ID); err != nil {
+		return InstallationActionResult{}, err
+	}
+	if err = p.deleteInstallation(installToDelete.ID); err != nil {
+		return InstallationActionResult{}, err
+	}
+
+	return InstallationActionResult{Installation: summary, Status: "delete_requested"}, nil
+}
+
+func (p *Plugin) buildCreateInstallation(userID string, input CreateInstallationInput) (*Installation, error) {
+	config := p.getConfiguration()
+	install := &Installation{
+		Name: standardizeName(input.Name),
+		InstallationDTO: cloud.InstallationDTO{
+			Installation: &cloud.Installation{},
+		},
+	}
+
+	if install.Name == "" || strings.HasPrefix(install.Name, "--") {
+		return nil, errors.New("must provide an installation name")
+	}
+	if !validInstallationName(install.Name) {
+		return nil, errors.Errorf("installation name %s is invalid: only letters, numbers, and hyphens are permitted", install.Name)
+	}
+
+	exists, err := p.installationWithNameExists(install.Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to determine if installation name is already taken")
+	}
+	if exists {
+		return nil, errors.Errorf("Installation name %s already exists. **NOTE**: installation names are reserved for 24 hours after deletion in order to support restoration. Please try a new name, wait 24 hours, or contact the Cloud Platform team for support.", install.Name)
+	}
+
+	install.Size = defaultString(input.Size, "miniSingleton")
+	if install.Size != "" && !Contains(validInstallationSizes, install.Size) {
+		return nil, fmt.Errorf("Invalid size: %s", install.Size)
+	}
+
+	install.Version = defaultString(input.Version, "latest")
+	if install.Version == "latest" {
+		install.Version, err = p.githubLatestVersion()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to determine latest tag for requested version 'latest'")
+		}
+		if install.Version == "" {
+			return nil, errors.New("failed to determine latest tag for requested version 'latest': got empty version")
+		}
+	}
+	install.Tag = install.Version
+	if err = validVersionOption(install.Version); err != nil {
+		return nil, errors.Wrap(err, "Invalid version number")
+	}
+
+	install.Affinity = defaultString(input.Affinity, cloud.InstallationAffinityMultiTenant)
+	if !cloud.IsSupportedAffinity(install.Affinity) {
+		return nil, errors.Errorf("invalid affinity option %s, must be %s or %s", install.Affinity, cloud.InstallationAffinityIsolated, cloud.InstallationAffinityMultiTenant)
+	}
+
+	install.License = defaultString(input.License, licenseOptionEnterprise)
+	if !validLicenseOption(install.License) {
+		return nil, errors.Errorf("invalid license option %s, valid options are %s", install.License, strings.Join(validLicenseOptions, ", "))
+	}
+
+	install.Image = defaultString(input.Image, defaultImage)
+	if !validImageName(install.Image) {
+		return nil, errors.Errorf("invalid image name %s, valid options are %s", install.Image, strings.Join(dockerRepoWhitelist, ", "))
+	}
+
+	install.Database = input.Database
+	if install.Database == "" {
+		install.Database = config.DefaultDatabase
+	}
+	if install.Database == "" {
+		install.Database = cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer
+	}
+	if !cloud.IsSupportedDatabase(install.Database) {
+		return nil, errors.Errorf("invalid database option %s; valid options are: %s, %s, %s",
+			install.Database,
+			cloud.InstallationDatabasePerseus,
+			cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
+			cloud.InstallationDatabaseMysqlOperator,
+		)
+	}
+
+	install.Filestore = input.Filestore
+	if install.Filestore == "" {
+		install.Filestore = config.DefaultFilestore
+	}
+	if install.Filestore == "" {
+		install.Filestore = cloud.InstallationFilestoreBifrost
+	}
+	if !cloud.IsSupportedFilestore(install.Filestore) {
+		return nil, errors.Errorf("invalid filestore option %s; must be %s, %s, %s, or %s",
+			install.Filestore,
+			cloud.InstallationFilestoreBifrost,
+			cloud.InstallationFilestoreMinioOperator,
+			cloud.InstallationFilestoreAwsS3,
+			cloud.InstallationFilestoreMultiTenantAwsS3,
+		)
+	}
+	if install.Filestore == cloud.InstallationFilestoreMultiTenantAwsS3 && install.License != licenseOptionEnterprise && install.License != licenseOptionE20 && install.License != licenseOptionEnterpriseAdvanced {
+		return nil, errors.Errorf("filestore option %s requires license option %s or %s or %s", cloud.InstallationFilestoreMultiTenantAwsS3, licenseOptionEnterprise, licenseOptionE20, licenseOptionEnterpriseAdvanced)
+	}
+
+	install.TestData = input.TestData
+	install.PriorityEnv = envMapFromInput(input.Env)
+	install.OwnerID = userID
+
+	return install, nil
+}
+
+func (p *Plugin) buildUpdateInstallationRequest(install *Installation, input UpdateInstallationInput) (*cloud.PatchInstallationRequest, []string, []string, []string, string, error) {
+	if input.Version == "" && input.License == "" && input.Size == "" && input.Image == "" && len(input.SetEnv) == 0 && len(input.ClearEnv) == 0 {
+		return nil, nil, nil, nil, "", errors.New("must specify at least one option: version, license, image, size, env, clear-env")
+	}
+
+	if input.Size != "" && !Contains(validInstallationSizes, input.Size) {
+		return nil, nil, nil, nil, "", fmt.Errorf("Invalid size: %s", input.Size)
+	}
+	if input.License != "" && !validLicenseOption(input.License) {
+		return nil, nil, nil, nil, "", errors.Errorf("invalid license option %s, valid options are %s", input.License, strings.Join(validLicenseOptions, ", "))
+	}
+	if input.Image != "" && !validImageName(input.Image) {
+		return nil, nil, nil, nil, "", errors.Errorf("invalid image name %s, valid options are %s", input.Image, strings.Join(dockerRepoWhitelist, ", "))
+	}
+
+	request := &cloud.PatchInstallationRequest{}
+	changedFields := []string{}
+
+	if input.Size != "" {
+		request.Size = &input.Size
+		changedFields = append(changedFields, "size")
+	}
+	if input.License != "" {
+		licenseValue := p.getLicenseValue(input.License)
+		request.License = &licenseValue
+		changedFields = append(changedFields, "license")
+	}
+	if input.Image != "" {
+		request.Image = &input.Image
+		changedFields = append(changedFields, "image")
+	}
+
+	requestedTag := ""
+	if input.Version != "" || input.Image != "" {
+		dockerTag := defaultString(install.Tag, install.Version)
+		dockerRepository := install.Image
+		if input.Version != "" {
+			dockerTag = input.Version
+			changedFields = append(changedFields, "version")
+		}
+		if input.Image != "" {
+			dockerRepository = input.Image
+		}
+		exists, err := p.dockerClient.ValidTag(dockerTag, dockerRepository)
+		if err != nil {
+			p.API.LogError(errors.Wrapf(err, "unable to check if %s:%s exists", dockerRepository, dockerTag).Error())
+		}
+		if !exists {
+			return nil, nil, nil, nil, "", errors.Errorf("%s is not a valid docker tag for repository %s", dockerTag, dockerRepository)
+		}
+		digest, err := p.dockerClient.GetDigestForTag(dockerTag, dockerRepository)
+		if err != nil {
+			return nil, nil, nil, nil, "", errors.Wrapf(err, "failed to find a manifest digest for version %s", dockerTag)
+		}
+		request.Version = &digest
+		requestedTag = dockerTag
+	}
+
+	setEnvKeys := sortedStringMapKeys(input.SetEnv)
+	clearEnvKeys := append([]string{}, input.ClearEnv...)
+	sort.Strings(clearEnvKeys)
+	if len(input.SetEnv) > 0 || len(input.ClearEnv) > 0 {
+		request.PriorityEnv = envMapFromInput(input.SetEnv)
+		for _, key := range input.ClearEnv {
+			request.PriorityEnv[key] = cloud.EnvVar{}
+		}
+		changedFields = append(changedFields, "env")
+	}
+
+	sort.Strings(changedFields)
+	return request, changedFields, setEnvKeys, clearEnvKeys, requestedTag, nil
+}
+
+func (p *Plugin) findRefInRefreshedList(userID string, ref InstallationRef, scope InstallationScope) (*Installation, error) {
+	if err := ref.validate(); err != nil {
+		return nil, err
+	}
+	installs, err := p.listInstallationsForUser(userID, ListInstallationsInput{Scope: scope, Refresh: true})
+	if err != nil {
+		return nil, err
+	}
+	return findInstallationInSlice(userID, ref, scope, installs)
+}
+
+func (ref InstallationRef) validate() error {
+	if (ref.ID == "" && ref.Name == "") || (ref.ID != "" && ref.Name != "") {
+		return errors.New("must provide exactly one installation id or name")
+	}
+	return nil
+}
+
+func (ref InstallationRef) matches(install *Installation) bool {
+	if install == nil {
+		return false
+	}
+	if ref.ID != "" {
+		return install.ID == ref.ID
+	}
+	return standardizeName(install.Name) == standardizeName(ref.Name)
+}
+
+func findInstallationInSlice(userID string, ref InstallationRef, scope InstallationScope, installs []*Installation) (*Installation, error) {
+	scope = defaultInstallationScope(scope)
+	if err := validateInstallationScope(scope); err != nil {
+		return nil, err
+	}
+
+	ref.Name = standardizeName(ref.Name)
+	for _, install := range installs {
+		if !ref.matches(install) {
+			continue
+		}
+		if installationInScope(userID, scope, install) {
+			return install, nil
+		}
+	}
+
+	if ref.Name != "" {
+		return nil, errors.Errorf("no installation with the name %s found", ref.Name)
+	}
+	return nil, errors.Errorf("no installation with the id %s found", ref.ID)
+}
+
+func filterInstallationsForScope(userID string, scope InstallationScope, installs []*Installation) []*Installation {
+	filtered := []*Installation{}
+	for _, install := range installs {
+		if installationInScope(userID, scope, install) {
+			filtered = append(filtered, install)
+		}
+	}
+	return filtered
+}
+
+func installationInScope(userID string, scope InstallationScope, install *Installation) bool {
+	if install == nil {
+		return false
+	}
+
+	switch scope {
+	case InstallationScopeMine:
+		return install.OwnerID == userID
+	case InstallationScopeShared:
+		return install.Shared
+	case InstallationScopeUpdatable:
+		return install.OwnerID == userID || (install.Shared && install.AllowSharedUpdates)
+	default:
+		return false
+	}
+}
+
+func defaultInstallationScope(scope InstallationScope) InstallationScope {
+	if scope == "" {
+		return InstallationScopeMine
+	}
+	return scope
+}
+
+func validateInstallationScope(scope InstallationScope) error {
+	switch scope {
+	case InstallationScopeMine, InstallationScopeShared, InstallationScopeUpdatable:
+		return nil
+	default:
+		return errors.Errorf("unknown installation scope %s", scope)
+	}
+}
+
+func dedupeInstallations(installs []*Installation) []*Installation {
+	seen := map[string]bool{}
+	deduped := []*Installation{}
+	for _, install := range installs {
+		if install == nil || seen[install.ID] {
+			continue
+		}
+		seen[install.ID] = true
+		deduped = append(deduped, install)
+	}
+	return deduped
+}
+
+func defaultString(value, defaultValue string) string {
+	if value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func envMapFromInput(input map[string]string) cloud.EnvVarMap {
+	if len(input) == 0 {
+		return nil
+	}
+
+	env := make(cloud.EnvVarMap, len(input))
+	for key, value := range input {
+		env[key] = cloud.EnvVar{Value: value}
+	}
+	return env
+}
+
+func sortedStringMapKeys(input map[string]string) []string {
+	keys := make([]string, 0, len(input))
+	for key := range input {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/server/installation_service_test.go
+++ b/server/installation_service_test.go
@@ -238,6 +238,22 @@ func TestInstallationServiceUpdate(t *testing.T) {
 		assert.NotContains(t, string(resultJSON), "secret-value")
 	})
 
+	t.Run("clear-env only without set-env", func(t *testing.T) {
+		installs := []*Installation{serviceTestInstall("install-id", "Install", "owner")}
+		plugin, cloudClient, _ := newServiceTestPlugin(t, installs)
+
+		result, err := plugin.updateInstallationForUser("owner", InstallationRef{Name: "install"}, UpdateInstallationInput{
+			ClearEnv: []string{"OLD_ENV"},
+		}, InstallationScopeMine)
+		require.NoError(t, err)
+
+		require.NotNil(t, cloudClient.patchRequest)
+		assert.Equal(t, cloud.EnvVarMap{"OLD_ENV": cloud.EnvVar{}}, cloudClient.patchRequest.PriorityEnv)
+		assert.Equal(t, []string{"env"}, result.ChangedFields)
+		assert.Empty(t, result.ChangedEnvKeys)
+		assert.Equal(t, []string{"OLD_ENV"}, result.ClearedEnvKeys)
+	})
+
 	t.Run("image-only update uses stored tag instead of stored digest", func(t *testing.T) {
 		install := serviceTestInstall("install-id", "Install", "owner")
 		install.Version = "sha256:stored-digest"

--- a/server/installation_service_test.go
+++ b/server/installation_service_test.go
@@ -1,0 +1,515 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallationServiceSanitizeAndSummary(t *testing.T) {
+	install := serviceTestInstall("install-id", "OwnerInstall", "owner")
+	install.License = "super-secret-license"
+	install.MattermostEnv = cloud.EnvVarMap{
+		serviceEnvironmentEnvVarKey: cloud.EnvVar{Value: "dev"},
+		"SECRET":                    cloud.EnvVar{Value: "secret-value"},
+	}
+	install.PriorityEnv = cloud.EnvVarMap{
+		serviceEnvironmentEnvVarKey: cloud.EnvVar{Value: "staging"},
+		"SAFE":                      cloud.EnvVar{Value: "safe-value"},
+	}
+	install.DNSRecords = []*cloud.InstallationDNS{{DomainName: "first.example.com"}, {DomainName: "second.example.com"}}
+
+	sanitized := sanitizeInstallationCopy(install)
+	require.NotNil(t, sanitized)
+	assert.Equal(t, "hidden", sanitized.License)
+	assert.Nil(t, sanitized.MattermostEnv)
+	assert.Nil(t, sanitized.PriorityEnv)
+	assert.Equal(t, "super-secret-license", install.License)
+	assert.Equal(t, "secret-value", install.MattermostEnv["SECRET"].Value)
+	assert.Equal(t, "safe-value", install.PriorityEnv["SAFE"].Value)
+
+	summary, err := installationSummary(install, true)
+	require.NoError(t, err)
+	assert.Equal(t, "first.example.com", summary.DNS)
+	assert.Equal(t, "staging", summary.ServiceEnvironment)
+	assert.NotEmpty(t, summary.InstallationLogsURL)
+	assert.NotEmpty(t, summary.ProvisionerLogsURL)
+
+	summaryJSON, err := json.Marshal(summary)
+	require.NoError(t, err)
+	assert.NotContains(t, string(summaryJSON), "super-secret-license")
+	assert.NotContains(t, string(summaryJSON), "secret-value")
+	assert.NotContains(t, string(summaryJSON), "safe-value")
+
+	wrapper, err := CreateInstallationWebWrapper(install)
+	require.NoError(t, err)
+	wrapperJSON, err := json.Marshal(wrapper)
+	require.NoError(t, err)
+	assert.Contains(t, string(wrapperJSON), "staging")
+	assert.NotContains(t, string(wrapperJSON), "super-secret-license")
+	assert.NotContains(t, string(wrapperJSON), "secret-value")
+	assert.NotContains(t, string(wrapperJSON), "safe-value")
+
+	placeholderSummary, err := installationSummary(&Installation{Name: "Deleted [ DELETED ]"}, true)
+	require.NoError(t, err)
+	assert.Equal(t, "Deleted [ DELETED ]", placeholderSummary.Name)
+	assert.Empty(t, placeholderSummary.InstallationLogsURL)
+	assert.Empty(t, placeholderSummary.ProvisionerLogsURL)
+}
+
+func TestInstallationServiceFindAndListScopes(t *testing.T) {
+	installs := []*Installation{
+		serviceTestInstall("owned-id", "OwnedInstall", "user-1"),
+		serviceTestInstall("private-other-id", "PrivateOther", "user-2"),
+		serviceTestInstall("shared-read-id", "SharedRead", "user-2"),
+		serviceTestInstall("shared-update-id", "SharedUpdate", "user-2"),
+	}
+	installs[2].Shared = true
+	installs[3].Shared = true
+	installs[3].AllowSharedUpdates = true
+
+	plugin, _, _ := newServiceTestPlugin(t, installs)
+
+	found, err := plugin.findInstallationForUser("user-1", InstallationRef{ID: "owned-id"}, InstallationScopeMine)
+	require.NoError(t, err)
+	assert.Equal(t, "OwnedInstall", found.Name)
+
+	found, err = plugin.findInstallationForUser("user-1", InstallationRef{Name: "OWNEDINSTALL"}, InstallationScopeMine)
+	require.NoError(t, err)
+	assert.Equal(t, "owned-id", found.ID)
+
+	_, err = plugin.findInstallationForUser("user-1", InstallationRef{ID: "private-other-id"}, InstallationScopeMine)
+	require.EqualError(t, err, "no installation with the id private-other-id found")
+
+	found, err = plugin.findInstallationForUser("user-1", InstallationRef{Name: "sharedread"}, InstallationScopeShared)
+	require.NoError(t, err)
+	assert.Equal(t, "shared-read-id", found.ID)
+
+	_, err = plugin.findInstallationForUser("user-1", InstallationRef{Name: "sharedread"}, InstallationScopeUpdatable)
+	require.EqualError(t, err, "no installation with the name sharedread found")
+
+	found, err = plugin.findInstallationForUser("user-1", InstallationRef{Name: "sharedupdate"}, InstallationScopeUpdatable)
+	require.NoError(t, err)
+	assert.Equal(t, "shared-update-id", found.ID)
+
+	_, err = plugin.findInstallationForUser("user-1", InstallationRef{}, InstallationScopeMine)
+	require.EqualError(t, err, "must provide exactly one installation id or name")
+
+	_, err = plugin.findInstallationForUser("user-1", InstallationRef{ID: "owned-id", Name: "owned"}, InstallationScopeMine)
+	require.EqualError(t, err, "must provide exactly one installation id or name")
+
+	_, err = plugin.findInstallationForUser("user-1", InstallationRef{ID: "owned-id"}, InstallationScope("bogus"))
+	require.EqualError(t, err, "unknown installation scope bogus")
+
+	owned, err := plugin.listInstallationsForUser("user-1", ListInstallationsInput{Refresh: false})
+	require.NoError(t, err)
+	require.Len(t, owned, 1)
+	assert.Equal(t, "owned-id", owned[0].ID)
+
+	shared, err := plugin.listInstallationsForUser("user-1", ListInstallationsInput{Scope: InstallationScopeShared, Refresh: false})
+	require.NoError(t, err)
+	require.Len(t, shared, 2)
+
+	updatable, err := plugin.listInstallationsForUser("user-1", ListInstallationsInput{Scope: InstallationScopeUpdatable, Refresh: false})
+	require.NoError(t, err)
+	require.Len(t, updatable, 2)
+	assert.ElementsMatch(t, []string{"owned-id", "shared-update-id"}, []string{updatable[0].ID, updatable[1].ID})
+}
+
+func TestInstallationServiceRefreshWithoutCleanup(t *testing.T) {
+	deleted := serviceTestInstall("deleted-id", "Deleted", "owner")
+	plugin, cloudClient, api := newServiceTestPlugin(t, []*Installation{deleted})
+	cloudClient.overrideGetInstallationDTO = &cloud.InstallationDTO{Installation: &cloud.Installation{
+		ID:      "deleted-id",
+		OwnerID: "owner",
+		State:   cloud.InstallationStateDeleted,
+	}}
+	api.On("KVCompareAndSet").Unset()
+
+	installs, err := plugin.listInstallationsForUser("owner", ListInstallationsInput{Scope: InstallationScopeMine, Refresh: true})
+	require.NoError(t, err)
+	require.Len(t, installs, 1)
+	assert.Equal(t, "deleted-id", installs[0].ID)
+	assert.Equal(t, "owner", installs[0].OwnerID)
+	assert.Equal(t, cloud.InstallationStateDeleted, installs[0].State)
+	assert.Contains(t, installs[0].Name, "DELETED")
+	api.AssertNotCalled(t, "KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything)
+}
+
+func TestInstallationServiceCreate(t *testing.T) {
+	t.Run("validates inputs", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			input       CreateInstallationInput
+			errContains string
+			installs    []*Installation
+		}{
+			{"missing name", CreateInstallationInput{Name: ""}, "must provide an installation name", nil},
+			{"invalid name", CreateInstallationInput{Name: "bad_name"}, "installation name bad_name is invalid", nil},
+			{"duplicate name", CreateInstallationInput{Name: "taken"}, "Installation name taken already exists", []*Installation{serviceTestInstall("taken-id", "taken", "owner")}},
+			{"invalid size", CreateInstallationInput{Name: "new", Size: "huge"}, "Invalid size: huge", nil},
+			{"invalid affinity", CreateInstallationInput{Name: "new", Affinity: "banana"}, "invalid affinity option banana", nil},
+			{"invalid license", CreateInstallationInput{Name: "new", License: "e30"}, "invalid license option e30", nil},
+			{"invalid image", CreateInstallationInput{Name: "new", Image: "mattermost/unknown"}, "invalid image name", nil},
+			{"invalid database", CreateInstallationInput{Name: "new", Database: "sqlite"}, "invalid database option sqlite", nil},
+			{"invalid filestore", CreateInstallationInput{Name: "new", Filestore: "local"}, "invalid filestore option local", nil},
+			{"multitenant s3 license", CreateInstallationInput{Name: "new", Filestore: cloud.InstallationFilestoreMultiTenantAwsS3, License: licenseOptionProfessional}, "requires license option", nil},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				plugin, _, _ := newServiceTestPlugin(t, test.installs)
+				_, err := plugin.createInstallationForUser("owner", test.input)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			})
+		}
+	})
+
+	t.Run("stores created install with digest request and requested tag", func(t *testing.T) {
+		plugin, cloudClient, _ := newServiceTestPlugin(t, nil)
+		plugin.dockerClient = &MockedDockerClient{tagExists: true, digest: "sha256:digest"}
+
+		install, err := plugin.createInstallationForUser("owner", CreateInstallationInput{
+			Name:    "Example",
+			Version: "9.5.0",
+			License: licenseOptionEnterprise,
+			Env:     map[string]string{"ENV1": "value1"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cloudClient.creationRequest)
+		assert.Equal(t, "example", cloudClient.creationRequest.Name)
+		assert.Equal(t, "sha256:digest", cloudClient.creationRequest.Version)
+		assert.Equal(t, "9.5.0", install.Tag)
+		assert.Equal(t, cloud.EnvVarMap{"ENV1": cloud.EnvVar{Value: "value1"}}, cloudClient.creationRequest.PriorityEnv)
+	})
+}
+
+func TestInstallationServiceUpdate(t *testing.T) {
+	t.Run("rejects empty and inaccessible shared updates", func(t *testing.T) {
+		installs := []*Installation{serviceTestInstall("shared-id", "Shared", "owner")}
+		installs[0].Shared = true
+		plugin, _, _ := newServiceTestPlugin(t, installs)
+
+		_, err := plugin.updateInstallationForUser("owner", InstallationRef{Name: "shared"}, UpdateInstallationInput{}, InstallationScopeMine)
+		require.EqualError(t, err, "must specify at least one option: version, license, image, size, env, clear-env")
+
+		_, err = plugin.updateInstallationForUser("other", InstallationRef{Name: "shared"}, UpdateInstallationInput{Size: "miniHA"}, InstallationScopeUpdatable)
+		require.EqualError(t, err, "no installation with the name shared found")
+	})
+
+	t.Run("converts license and docker tag without returning env values", func(t *testing.T) {
+		installs := []*Installation{serviceTestInstall("install-id", "Install", "owner")}
+		plugin, cloudClient, _ := newServiceTestPlugin(t, installs)
+		plugin.configuration.E20License = "license-value"
+		plugin.dockerClient = &MockedDockerClient{tagExists: true, digest: "sha256:new"}
+
+		result, err := plugin.updateInstallationForUser("owner", InstallationRef{Name: "install"}, UpdateInstallationInput{
+			Version:  "9.5.0",
+			License:  licenseOptionE20,
+			Image:    imageTE,
+			Size:     "miniHA",
+			SetEnv:   map[string]string{"SECRET_ENV": "secret-value"},
+			ClearEnv: []string{"OLD_ENV"},
+		}, InstallationScopeMine)
+		require.NoError(t, err)
+
+		require.NotNil(t, cloudClient.patchRequest)
+		require.NotNil(t, cloudClient.patchRequest.Version)
+		require.NotNil(t, cloudClient.patchRequest.License)
+		assert.Equal(t, "sha256:new", *cloudClient.patchRequest.Version)
+		assert.Equal(t, "license-value", *cloudClient.patchRequest.License)
+		assert.Equal(t, cloud.EnvVarMap{
+			"SECRET_ENV": cloud.EnvVar{Value: "secret-value"},
+			"OLD_ENV":    cloud.EnvVar{},
+		}, cloudClient.patchRequest.PriorityEnv)
+		assert.ElementsMatch(t, []string{"env", "image", "license", "size", "version"}, result.ChangedFields)
+		assert.Equal(t, []string{"SECRET_ENV"}, result.ChangedEnvKeys)
+		assert.Equal(t, []string{"OLD_ENV"}, result.ClearedEnvKeys)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		assert.NotContains(t, string(resultJSON), "secret-value")
+	})
+
+	t.Run("image-only update uses stored tag instead of stored digest", func(t *testing.T) {
+		install := serviceTestInstall("install-id", "Install", "owner")
+		install.Version = "sha256:stored-digest"
+		install.Tag = "9.5.0"
+		plugin, cloudClient, _ := newServiceTestPlugin(t, []*Installation{install})
+		dockerClient := &MockedDockerClient{tagExists: true, digest: "sha256:new-image-digest"}
+		plugin.dockerClient = dockerClient
+
+		result, err := plugin.updateInstallationForUser("owner", InstallationRef{Name: "install"}, UpdateInstallationInput{
+			Image: imageTE,
+		}, InstallationScopeMine)
+		require.NoError(t, err)
+
+		require.NotNil(t, cloudClient.patchRequest)
+		require.NotNil(t, cloudClient.patchRequest.Version)
+		assert.Equal(t, "sha256:new-image-digest", *cloudClient.patchRequest.Version)
+		assert.Equal(t, "9.5.0", result.Installation.VersionTag)
+		assert.Equal(t, []dockerClientCall{{tag: "9.5.0", repository: imageTE}}, dockerClient.validTagCalls)
+		assert.Equal(t, []dockerClientCall{{tag: "9.5.0", repository: imageTE}}, dockerClient.getDigestCalls)
+	})
+
+	t.Run("shared update after redacted read preserves sensitive persisted fields", func(t *testing.T) {
+		shared := serviceTestInstall("shared-id", "Shared", "owner")
+		shared.Shared = true
+		shared.AllowSharedUpdates = true
+		shared.License = "secret-license"
+		shared.MattermostEnv = cloud.EnvVarMap{"SECRET": cloud.EnvVar{Value: "secret-value"}}
+		shared.PriorityEnv = cloud.EnvVarMap{"PRIORITY": cloud.EnvVar{Value: "priority-value"}}
+		plugin, cloudClient, api := newServiceTestPlugin(t, []*Installation{shared})
+		cloudClient.overrideGetInstallationDTO = &cloud.InstallationDTO{
+			Installation: shared.Clone(),
+		}
+		cloudClient.mockedCloudInstallationsDTO = serviceDTOs(shared)
+
+		redacted, err := plugin.getUpdatedSharedInstallations(true)
+		require.NoError(t, err)
+		require.Len(t, redacted, 1)
+		assert.Equal(t, "hidden", redacted[0].License)
+		assert.Nil(t, redacted[0].MattermostEnv)
+		assert.Nil(t, redacted[0].PriorityEnv)
+
+		var persisted []*Installation
+		api.On("KVCompareAndSet").Unset()
+		api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				require.NoError(t, json.Unmarshal(args.Get(2).([]byte), &persisted))
+			}).
+			Return(true, nil)
+
+		_, err = plugin.updateInstallationForUser("other", InstallationRef{Name: "shared"}, UpdateInstallationInput{Size: "miniHA"}, InstallationScopeUpdatable)
+		require.NoError(t, err)
+		require.Len(t, persisted, 1)
+		assert.Equal(t, "secret-license", persisted[0].License)
+		assert.Equal(t, "secret-value", persisted[0].MattermostEnv["SECRET"].Value)
+		assert.Equal(t, "priority-value", persisted[0].PriorityEnv["PRIORITY"].Value)
+	})
+}
+
+func TestInstallationServiceLifecycleActions(t *testing.T) {
+	t.Run("restart patches env and respects shared update gate", func(t *testing.T) {
+		installs := []*Installation{serviceTestInstall("shared-id", "Shared", "owner")}
+		installs[0].Shared = true
+		plugin, _, _ := newServiceTestPlugin(t, installs)
+
+		_, err := plugin.restartInstallationForUser("other", InstallationRef{Name: "shared"}, InstallationScopeUpdatable)
+		require.EqualError(t, err, "no installation with the name shared found")
+
+		installs[0].AllowSharedUpdates = true
+		plugin, cloudClient, _ := newServiceTestPlugin(t, installs)
+		result, err := plugin.restartInstallationForUser("other", InstallationRef{Name: "shared"}, InstallationScopeUpdatable)
+		require.NoError(t, err)
+		assert.Equal(t, "restart_requested", result.Status)
+		assert.Equal(t, "shared-id", cloudClient.patchInstallationID)
+		assert.Contains(t, cloudClient.patchRequest.MattermostEnv, "CLOUD_PLUGIN_RESTART")
+	})
+
+	t.Run("hibernate and wake enforce state and owner", func(t *testing.T) {
+		stable := serviceTestInstall("stable-id", "Stable", "owner")
+		hibernating := serviceTestInstall("hibernating-id", "Hibernating", "owner")
+		hibernating.State = cloud.InstallationStateHibernating
+		plugin, cloudClient, _ := newServiceTestPlugin(t, []*Installation{stable, hibernating})
+		cloudClient.mockedCloudInstallationsDTO = serviceDTOs(stable, hibernating)
+
+		result, err := plugin.hibernateInstallationForUser("owner", InstallationRef{Name: "stable"})
+		require.NoError(t, err)
+		assert.Equal(t, "hibernate_requested", result.Status)
+		assert.Equal(t, "stable-id", cloudClient.hibernatedInstallationID)
+
+		_, err = plugin.hibernateInstallationForUser("other", InstallationRef{Name: "stable"})
+		require.EqualError(t, err, "no installation with the name stable found")
+
+		_, err = plugin.hibernateInstallationForUser("owner", InstallationRef{Name: "hibernating"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be stable to hibernate")
+
+		result, err = plugin.wakeInstallationForUser("owner", InstallationRef{Name: "hibernating"})
+		require.NoError(t, err)
+		assert.Equal(t, "wake_requested", result.Status)
+		assert.Equal(t, "hibernating-id", cloudClient.wokenInstallationID)
+
+		_, err = plugin.wakeInstallationForUser("owner", InstallationRef{Name: "stable"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be hibernating to wake up")
+	})
+}
+
+func TestInstallationServiceSharingDeletionLockAndDelete(t *testing.T) {
+	t.Run("sharing updates and unsharing clears update permission", func(t *testing.T) {
+		install := serviceTestInstall("install-id", "Install", "owner")
+		plugin, _, _ := newServiceTestPlugin(t, []*Installation{install})
+		plugin.cloudClient.(*MockClient).mockedCloudInstallationsDTO = serviceDTOs(install)
+
+		result, err := plugin.setInstallationSharingForUser("owner", InstallationRef{Name: "install"}, true, true)
+		require.NoError(t, err)
+		assert.True(t, result.Installation.Shared)
+		assert.True(t, result.Installation.AllowSharedUpdates)
+
+		result, err = plugin.setInstallationSharingForUser("owner", InstallationRef{Name: "install"}, false, true)
+		require.NoError(t, err)
+		assert.False(t, result.Installation.Shared)
+		assert.False(t, result.Installation.AllowSharedUpdates)
+	})
+
+	t.Run("deletion lock counts all owned locked installs before enforcing limit", func(t *testing.T) {
+		target := serviceTestInstall("target-id", "Target", "owner")
+		locked := serviceTestInstall("locked-id", "Locked", "owner")
+		locked.DeletionLocked = true
+		plugin, cloudClient, _ := newServiceTestPlugin(t, []*Installation{target, locked})
+		cloudClient.mockedCloudInstallationsDTO = serviceDTOs(target, locked)
+		plugin.configuration.DeletionLockInstallationsAllowedPerPerson = "1"
+
+		_, err := plugin.setDeletionLockForUser("owner", InstallationRef{Name: "target"}, true)
+		require.EqualError(t, err, "you may only have at most 1 installations locked for deletion at a time")
+		assert.Empty(t, cloudClient.lockedInstallationID)
+	})
+
+	t.Run("already locked target does not fail due to its own lock", func(t *testing.T) {
+		target := serviceTestInstall("target-id", "Target", "owner")
+		target.DeletionLocked = true
+		plugin, cloudClient, _ := newServiceTestPlugin(t, []*Installation{target})
+		cloudClient.mockedCloudInstallationsDTO = serviceDTOs(target)
+		plugin.configuration.DeletionLockInstallationsAllowedPerPerson = "1"
+
+		result, err := plugin.setDeletionLockForUser("owner", InstallationRef{Name: "target"}, true)
+		require.NoError(t, err)
+		assert.True(t, result.Installation.DeletionLocked)
+		assert.Equal(t, "target-id", cloudClient.lockedInstallationID)
+	})
+
+	t.Run("deletion lock validates config target and owner", func(t *testing.T) {
+		target := serviceTestInstall("target-id", "Target", "owner")
+		plugin, _, _ := newServiceTestPlugin(t, []*Installation{target})
+		plugin.cloudClient.(*MockClient).mockedCloudInstallationsDTO = serviceDTOs(target)
+
+		_, err := plugin.setDeletionLockForUser("owner", InstallationRef{}, true)
+		require.EqualError(t, err, "must provide an installation ID or name")
+
+		_, err = plugin.setDeletionLockForUser("other", InstallationRef{Name: "target"}, true)
+		require.EqualError(t, err, "no installations found for the given User ID")
+
+		_, err = plugin.setDeletionLockForUser("owner", InstallationRef{Name: "missing"}, true)
+		require.EqualError(t, err, "installation to be locked not found")
+
+		plugin.configuration.DeletionLockInstallationsAllowedPerPerson = "invalid"
+		_, err = plugin.setDeletionLockForUser("owner", InstallationRef{Name: "target"}, true)
+		require.EqualError(t, err, "invalid value for DeletionLockInstallationsAllowedPerPerson")
+	})
+
+	t.Run("deletion lock and unlock call provisioner", func(t *testing.T) {
+		target := serviceTestInstall("target-id", "Target", "owner")
+		plugin, cloudClient, _ := newServiceTestPlugin(t, []*Installation{target})
+		cloudClient.mockedCloudInstallationsDTO = serviceDTOs(target)
+
+		result, err := plugin.setDeletionLockForUser("owner", InstallationRef{ID: "target-id"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "deletion_lock_updated", result.Status)
+		assert.Equal(t, "target-id", cloudClient.lockedInstallationID)
+
+		result, err = plugin.setDeletionLockForUser("owner", InstallationRef{ID: "target-id"}, false)
+		require.NoError(t, err)
+		assert.Equal(t, "target-id", cloudClient.unlockedInstallationID)
+		assert.False(t, result.Installation.DeletionLocked)
+	})
+
+	t.Run("delete requires confirmation and calls provisioner before KV delete", func(t *testing.T) {
+		target := serviceTestInstall("delete-id", "DeleteMe", "owner")
+		plugin, cloudClient, api := newServiceTestPlugin(t, []*Installation{target})
+		api.On("KVCompareAndSet").Unset()
+		api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				assert.Equal(t, "delete-id", cloudClient.deletedInstallationID)
+			}).
+			Return(true, nil)
+
+		_, err := plugin.deleteInstallationForUser("owner", InstallationRef{Name: "deleteme"}, "wrong")
+		require.EqualError(t, err, "confirmation name wrong does not match installation name DeleteMe")
+		assert.Empty(t, cloudClient.deletedInstallationID)
+
+		result, err := plugin.deleteInstallationForUser("owner", InstallationRef{Name: "deleteme"}, "deleteme")
+		require.NoError(t, err)
+		assert.Equal(t, "delete_requested", result.Status)
+		assert.Equal(t, "delete-id", cloudClient.deletedInstallationID)
+
+		_, err = plugin.deleteInstallationForUser("owner", InstallationRef{ID: "missing-id"}, "deleteme")
+		require.EqualError(t, err, "no installation with the id missing-id found")
+	})
+}
+
+func newServiceTestPlugin(t *testing.T, installs []*Installation) (*Plugin, *MockClient, *plugintest.API) {
+	t.Helper()
+
+	installBytes, err := json.Marshal(installs)
+	require.NoError(t, err)
+	if installs == nil {
+		installBytes = nil
+	}
+
+	cloudClient := &MockClient{}
+	plugin := &Plugin{
+		cloudClient:  cloudClient,
+		dockerClient: &MockedDockerClient{tagExists: true},
+		configuration: &configuration{
+			InstallationDNS: "example.com",
+			DeletionLockInstallationsAllowedPerPerson: "2",
+			EnterpriseLicense:                         "enterprise-license",
+			EnterpriseAdvancedLicense:                 "enterprise-advanced-license",
+			ProfessionalLicense:                       "professional-license",
+			E20License:                                "e20-license",
+			E10License:                                "e10-license",
+		},
+		latestMattermostVersion: &latestMattermostVersionCache{version: "9.5.0", timestamp: time.Now()},
+	}
+
+	api := &plugintest.API{}
+	api.On("KVGet", mock.AnythingOfType("string")).Return(installBytes, nil)
+	api.On("KVCompareAndSet", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(true, nil)
+	api.On("LogWarn", mock.AnythingOfType("string")).Return(nil)
+	api.On("LogError", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(nil)
+	plugin.SetAPI(api)
+
+	return plugin, cloudClient, api
+}
+
+func serviceTestInstall(id, name, ownerID string) *Installation {
+	return &Installation{
+		Name: name,
+		InstallationDTO: cloud.InstallationDTO{
+			Installation: &cloud.Installation{
+				ID:        id,
+				OwnerID:   ownerID,
+				Name:      name,
+				Version:   "9.4.0",
+				Image:     imageEE,
+				Size:      "miniSingleton",
+				Database:  cloud.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
+				Filestore: cloud.InstallationFilestoreBifrost,
+				Affinity:  cloud.InstallationAffinityMultiTenant,
+				State:     cloud.InstallationStateStable,
+				CreateAt:  1234,
+			},
+		},
+		Tag: "9.4.0",
+	}
+}
+
+func serviceDTOs(installs ...*Installation) []*cloud.InstallationDTO {
+	dtos := make([]*cloud.InstallationDTO, 0, len(installs))
+	for _, install := range installs {
+		dtos = append(dtos, &cloud.InstallationDTO{
+			Installation: install.Clone(),
+			DNSRecords:   install.DNSRecords,
+		})
+	}
+	return dtos
+}


### PR DESCRIPTION
#### Summary

Introduces `server/installation_service.go` with a typed `InstallationRef` / `InstallationScope` / `*Input` / `*Summary` surface and `*ForUser` methods that own validation, ownership/scope checks, and KV writes. Refactors slash-command handlers to thin adapters over the service so future callers (webapp, MCP) share the same paths.

Risk fixes that go with the refactor:

- `sanitizeInstallationCopy` returns a copy via in-place shallow copy + `HideSensitiveFields`. Callers always get a non-nil sanitized install and the original KV-backed pointer keeps its License / MattermostEnv / PriorityEnv data — the previous in-place redaction could persist a redacted version back to KV.
- `deleteInstallation` returns an error when the installation ID is missing instead of panicking.
- `setDeletionLockForUser` counts every owned lock before enforcing the per-user limit and now persists the lock state to KV (matching `setInstallationSharingForUser`). The previous deletion-lock counting could undercount existing locks when the target was found early.
- `listInstallationsForUser`'s refresh path passes `cleanupDeleted=false` so MCP/webapp refresh paths do not silently delete KV records. Slash `list` keeps cleanup on its existing path.
- `deletedInstallationPlaceholder` always reports `state=deleted`, so the `[ DELETED ]` name and state stay consistent.
- Misleading `installationID must not be empty` message replaced; pre-existing `updateRequester` typo fixed.

Adds `server/installation_service_test.go` and `server/api_test.go` covering scope filtering, sharing/lock/delete flows, refresh-without-cleanup, and the deletion-lock HTTP handlers.

This is the foundation for a follow-up PR that exposes the same service as a cross-plugin MCP server for the Agents plugin.

#### Ticket Link

NONE

#### Release Note

\`\`\`release-note
NONE
\`\`\`

Made with [Cursor](https://cursor.com)